### PR TITLE
Fix UnboundLocalError and wrong error messages on dict validation

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -93,6 +93,7 @@ class Schema(object):
             coverage = set()  # non-optional schema keys that were matched
             for key, value in data.items():
                 valid = False
+                skey = None
                 for skey, svalue in s.items():
                     try:
                         nkey = Schema(skey, error=e).validate(key)
@@ -108,12 +109,12 @@ class Schema(object):
                         break
                 if valid:
                     new[nkey] = nvalue
-                elif type(skey) is not Optional:
+                elif type(skey) is not Optional and skey is not None:
                     if x is not None:
                         raise SchemaError(['key %r is required' % key] +
                                           x.autos, [e] + x.errors)
                     else:
-                        raise SchemaError('key %r is required' % key, e)
+                        raise SchemaError('key %r is required' % skey, e)
             coverage = set(k for k in coverage if type(k) is not Optional)
             required = set(k for k in s if type(k) is not Optional)
             if coverage != required:

--- a/test_schema.py
+++ b/test_schema.py
@@ -85,6 +85,24 @@ def test_dict():
             {'n': 5, 'f': 3.14}) == {'n': 5, 'f': 3.14}
     with SE: Schema({'n': int, 'f': float}).validate(
             {'n': 3.14, 'f': 5})
+    with SE:
+        try:
+            Schema({'key': 5}).validate({})
+        except SchemaError as e:
+            assert e.args[0] == "missed keys set(['key'])"
+            raise
+    with SE:
+        try:
+            Schema({'key': 5}).validate({'n': 5})
+        except SchemaError as e:
+            assert e.args[0] == "key 'key' is required"
+            raise
+    with SE:
+        try:
+            Schema({}).validate({'n': 5})
+        except SchemaError as e:
+            assert e.args[0] == "wrong keys {} in {'n': 5}"
+            raise
 
 
 def test_dict_keys():


### PR DESCRIPTION
Some degenerate scenarios were causing Schema to explode with UnboundLocalError: local variable 'skey' referenced before assignment.

Other scenarios led to a correct SchemaError, but with a backwards message (complaining that a provided key didn't exist, instead of complaining about the missing key from the schema).

Thanks! :)
