### PR TITLE
Fixed wrong error message on optional key dict validate

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -111,7 +111,7 @@ class Schema(object):
                         break
                 if valid:
                     new[nkey] = nvalue
-                elif type(skey) is not Optional and skey is not None:
+                elif skey is not None:
                     if x is not None:
                         raise SchemaError(['key %r is required' % key] +
                                           x.autos, [e] + x.errors)

--- a/test_schema.py
+++ b/test_schema.py
@@ -149,6 +149,10 @@ def test_nice_errors():
         Schema(Use(float), error='should be a number').validate('x')
     except SchemaError as e:
         assert e.code == 'should be a number'
+    try:
+        Schema({Optional('i'): Use(int, error='should be a number')}).validate({'i': 'x'})
+    except SchemaError as e:
+        assert e.code == 'should be a number'
 
 
 def test_use_error_handling():


### PR DESCRIPTION
`Schema({Optional('i'): Use(int)}).validate({'i': 'x'})`

Gave the error:
`wrong keys {} in {'i': 'x'}`

Even if the custom error was set:

`Schema({Optional('i'): Use(int, error='should be a number')}).validate({'i': 'x'})`
