### PR TITLE
Make empty Or raise SchemaError. Fixes #13.

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -47,7 +47,7 @@ class And(object):
 class Or(And):
 
     def validate(self, data):
-        x = None
+        x = SchemaError([], [])
         for s in [Schema(s, error=self._error) for s in self._args]:
             try:
                 return s.validate(data)

--- a/test_schema.py
+++ b/test_schema.py
@@ -66,6 +66,8 @@ def test_or():
     assert Or(int, dict).validate(5) == 5
     assert Or(int, dict).validate({}) == {}
     with SE: Or(int, dict).validate('hai')
+    assert Or(int).validate(4)
+    with SE: Or().validate(2)
 
 
 def test_validate_list():


### PR DESCRIPTION
Or did fail to fail properly when called with no arguments (i.e. `Or().validate(42)`).

This PR is to fix that error reported in #13.
