### PR TITLE
Handle wrong keys better. Fixes #3 and #15

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,7 +194,7 @@ You can specify keys as schemas too:
     ...                   10: 'not None here'})
     Traceback (most recent call last):
     ...
-    SchemaError: key 10 is required
+    SchemaError: invalid value for key 10
     None does not match 'not None here'
 
 This is useful if you want to check certain key-values, but don't care
@@ -232,7 +232,7 @@ for the same data:
     >>> Schema({'password': And(str, lambda s: len(s) > 6)}).validate({'password': 'hai'})
     Traceback (most recent call last):
     ...
-    SchemaError: key 'password' is required
+    SchemaError: invalid value for key 'password'
     <lambda>('hai') should evaluate to True
 
     >>> Schema(And(Or(int, float), lambda x: x > 0)).validate(3.1415)

--- a/schema.py
+++ b/schema.py
@@ -134,10 +134,8 @@ class Schema(object):
                     new[nkey] = nvalue
                 elif skey is not None:
                     if x is not None:
-                        raise SchemaError(['key %r is required' % key] +
+                        raise SchemaError(['invalid value for key %r' % key] +
                                           x.autos, [e] + x.errors)
-                    else:
-                        raise SchemaError('key %r is required' % skey, e)
             coverage = set(k for k in coverage if type(k) is not Optional)
             required = set(k for k in s if type(k) is not Optional)
             if coverage != required:

--- a/test_schema.py
+++ b/test_schema.py
@@ -113,13 +113,21 @@ def test_dict():
         try:
             Schema({'key': 5}).validate({'n': 5})
         except SchemaError as e:
-            assert e.args[0] == "key 'key' is required"
+            assert e.args[0] in ["missed keys set(['key'])",
+                                 "missed keys {'key'}"]  # Python 3 style
             raise
     with SE:
         try:
             Schema({}).validate({'n': 5})
         except SchemaError as e:
             assert e.args[0] == "wrong keys {} in {'n': 5}"
+            raise
+    with SE:
+        try:
+            Schema({'key': 5}).validate({'key': 5, 'n': 5})
+        except SchemaError as e:
+            assert e.args[0] in ["wrong keys {'key': 5} in {'key': 5, 'n': 5}",
+                                 "wrong keys {'key': 5} in {'n': 5, 'key': 5}"]
             raise
 
 


### PR DESCRIPTION
This PR fixes problems for wrong keys (see 2 bugs reports).

I simply removed a case which is always handle afterwards.

More precisely, if a key is missing, instead of sometimes stopping there and sometimes reporting the set of missing mandatory keys, now it always reports the set of mandatory keys.

```
>>> Schema({'foo': str, 'bar': str}).validate({'foo': 'blah'})
Traceback (most recent call last):
…
schema.SchemaError: missed keys set(['bar'])
>>> Schema({'bar': str}).validate({'foo': 'blah'}) # I fixed unit test for that one
Traceback (most recent call last):
…
schema.SchemaError: missed keys set(['bar'])
```

The only case where it stops before for “missing” keys is when in fact the key was present but failed internally; I changed the error message in that case to be clearer.

```
>>> Schema({'foo': str}).validate({'foo': 42})
Traceback (most recent call last):
…
schema.SchemaError: invalid value for key 'foo'
42 should be instance of <type 'str'>
```

By the way, I could make sense to make the error message for wrong keys clearer as well, I don't really understand it right now… but maybe it's me

```
>>> Schema({'key': 5}).validate({'key': 5, 'n': 5})
Traceback (most recent call last):
…
schema.SchemaError: wrong keys {'key': 5} in {'key': 5, 'n': 5}
```
