### PR TITLE
Add default values handling. Fixes #12.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -225,6 +225,28 @@ You can mark a key as optional as follows:
     ...         Optional('occupation'): str}).validate({'name': 'Sam'})
     {'name': 'Sam'}
 
+And if you want to give a default value, simply use the keyword argument
+``default``:
+
+.. code:: python
+
+    >>> from schema import Optional, Use, Or
+    >>> Schema({'event': str,
+    ...        # use the default argument for schema classes
+    ...        Optional('date'): Use(int, default=2012),
+    ...        # wrap other objects in a Schema class to add a default value
+    ...        Optional('comment'): Schema(str, default='Initial import'),
+    ...        }).validate({'event': 'First commit'})
+    {'comment': 'Initial import', 'date': 2012, 'event': 'First commit'}
+    >>> # advanced use:
+    ... Schema({
+    ...        # Optional key is a type, it gets instantiated as a default
+    ...        Optional(int): Or(True, False, default=False),
+    ...        # but it is possible to use the default attribute as well
+    ...        Optional(int, default=42): Use(str, default='The answer'),
+    ...        }).validate({})
+    {0: False, 42: 'The answer'}
+
 **schema** has classes ``And`` and ``Or`` that help validating several schemas
 for the same data:
 


### PR DESCRIPTION
This PR adds a way to handle default values for optional keys, as requested by #12.

You can pass the `default` keyword argument quite everywhere to specify a default, and that default is used if the corresponding key is optional:

```
>>> Schema({
...         'event': str,
...         Optional('date'): Use(int, default=2012),
...     }).validate({'event': 'First commit'})
{'date': 2012, 'event': 'First commit'}
```

You can also use the `Default` class, which wraps whatever you gave as the first argument, and tries to find the appropriate default value (here `0` for an `int`):

```
>>> Schema({
...         'account': str,
...         Optional('amount'): Default(int),
...     }).validate({'account': 'Piggy bank'})
{'account': 'Piggy bank', 'amount': 0}
```

Of course, your need to give a proper default value, or else it complains, raising a `ValueError` (I think it is important that this is not a `SchemaError`, because that one means that the programmer made a mistake, nothing to do with the user data to validate):

```
>>> Use(int, default='two')
Traceback (most recent call last):
…
ValueError: Use(<type 'int'>) does not validate its default: two
```

And in case your optional key is a `type`, you can specify its default value as well:

```
>>> Schema({
...         Optional(int, default=42): Or(1, 2, 3, 4, default=3)
...     }).validate({})
{42: 3}
```

Tell me what you think!
