### PR TITLE
Increase Optional's priority

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -74,11 +74,18 @@ class Use(object):
 
 
 def priority(s):
+    """Return priority for a give object.
+
+    :rtype: int
+    """
     if type(s) in (list, tuple, set, frozenset):
         return 6
     if type(s) is dict:
         return 5
-    if hasattr(s, 'validate'):
+    # We exclude Optional from the test, otherwise it will make a
+    # catch-all rule like "str" take precedence over any optional field,
+    # which would be inintuitive.
+    if hasattr(s, 'validate')  and not type(s) is Optional:
         return 4
     if type(s) is type:
         return 3

--- a/test_schema.py
+++ b/test_schema.py
@@ -138,6 +138,12 @@ def test_dict_optional_keys():
             {'a': 1, 'b': 2}) == {'a': 1, 'b': 2}
 
 
+def test_dict_optional_keys_with_catch_all():
+    """Verify that optional keys still take precedence over catch-all."""
+    with SE:
+        Schema({str: object, Optional("b"): 1}).validate({"b": 2})
+
+
 def test_complex():
     s = Schema({'<file>': And([Use(open)], lambda l: len(l)),
                 '<path>': os.path.exists,


### PR DESCRIPTION
The rationale behind this PR is that the presence of a catch-all key should not prevent `Optional` from matching first. This PR effectively increases `Optional`'s priority to achieve that. A test is included.
