### PR TITLE
Add error name for dict

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ entries with personal information:
 
 .. code:: python
 
-    >>> from schema import Schema, And, Use, Optional
+    >>> from schema import Schema, And, Use, Optional, SchemaError
 
     >>> schema = Schema([{'name': And(str, len),
     ...                   'age':  And(Use(int), lambda n: 18 <= n <= 99),
@@ -194,8 +194,7 @@ You can specify keys as schemas too:
     ...                   10: 'not None here'})
     Traceback (most recent call last):
     ...
-    SchemaError: key 10 is required
-    None does not match 'not None here'
+    SchemaError: None does not match 'not None here'
 
 This is useful if you want to check certain key-values, but don't care
 about other:
@@ -232,8 +231,7 @@ for the same data:
     >>> Schema({'password': And(str, lambda s: len(s) > 6)}).validate({'password': 'hai'})
     Traceback (most recent call last):
     ...
-    SchemaError: key 'password' is required
-    <lambda>('hai') should evaluate to True
+    SchemaError: <lambda>('hai') should evaluate to True
 
     >>> Schema(And(Or(int, float), lambda x: x > 0)).validate(3.1415)
     3.1415
@@ -255,6 +253,20 @@ a built-in one.
 You can see all errors that occured by accessing exception's ``exc.autos``
 for auto-generated error messages, and ``exc.errors`` for errors
 which had ``error`` text passed to them.
+
+If you are using a dict, you can introspect the key for which the value
+generated an error by using the ``name`` attribute of the exception. For
+instance:
+
+.. code:: python
+
+    >>> schema = {"year": Use(int, error="Invalid year")}
+    >>> try:
+    ...     Schema(schema).validate({"year": "XVII"})
+    ... except SchemaError as e:
+    ...     response = {e.name: e.code}
+    >>> response
+    {'year': 'Invalid year'}
 
 You can exit with ``sys.exit(exc.code)`` if you want to show the messages
 to the user without traceback. ``error`` messages are given precedence in that

--- a/test_schema.py
+++ b/test_schema.py
@@ -102,6 +102,7 @@ def test_dict():
             {'n': 5, 'f': 3.14}) == {'n': 5, 'f': 3.14}
     with SE: Schema({'n': int, 'f': float}).validate(
             {'n': 3.14, 'f': 5})
+
     with SE:
         try:
             Schema({'key': 5}).validate({})
@@ -109,12 +110,14 @@ def test_dict():
             assert e.args[0] in ["missed keys set(['key'])",
                                  "missed keys {'key'}"]  # Python 3 style
             raise
+
     with SE:
         try:
             Schema({'key': 5}).validate({'n': 5})
         except SchemaError as e:
             assert e.args[0] == "key 'key' is required"
             raise
+
     with SE:
         try:
             Schema({}).validate({'n': 5})
@@ -156,18 +159,29 @@ def test_complex():
 
 
 def test_nice_errors():
+
     try:
         Schema(int, error='should be integer').validate('x')
     except SchemaError as e:
         assert e.errors == ['should be integer']
+
     try:
         Schema(Use(float), error='should be a number').validate('x')
     except SchemaError as e:
         assert e.code == 'should be a number'
+
     try:
         Schema({Optional('i'): Use(int, error='should be a number')}).validate({'i': 'x'})
     except SchemaError as e:
+        assert e.name == 'i'
         assert e.code == 'should be a number'
+
+    try:
+        Schema({"a": int}).validate({"a": "e"})
+
+    except SchemaError as e:
+        assert e.name == "a"
+        assert e.code == "'e' should be instance of <type 'int'>"
 
 
 def test_use_error_handling():


### PR DESCRIPTION
The idea behind this PR is for HTTP views. Let's say we want to validate the user input that is passed to an HTTP endpoint through url parameters, JSON or form data. This is usually under the form of a `dict`. Thanks to this PR, we can validate those data, catch the `SchemaError` exception and get the key that was invalid, as well as its error content. This is useful to display error next to a form field for instance.
