### PR TITLE
Handle wrong keys better

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -106,11 +106,11 @@ class Schema(object):
             return type(s)(Or(*s, error=e).validate(d) for d in data)
         if type(s) is dict:
             data = Schema(dict, error=e).validate(data)
-            new = type(data)()
+            new = type(data)()  # new - is a dict of the validated values
             x = None
             coverage = set()  # non-optional schema keys that were matched
+            # for each key and value find a schema entry matching them, if any
             sorted_skeys = list(sorted(s, key=priority))
-
             for key, value in data.items():
                 valid = False
                 skey = None
@@ -141,7 +141,10 @@ class Schema(object):
             if coverage != required:
                 raise SchemaError('missed keys %r' % (required - coverage), e)
             if len(new) != len(data):
-                raise SchemaError('wrong keys %r in %r' % (new, data), e)
+                wrong_keys = set(data.keys()) - set(new.keys())
+                s_wrong_keys = ', '.join('%r' % k for k in sorted(wrong_keys))
+                raise SchemaError('wrong keys %s in %r' % (s_wrong_keys, data),
+                                  e)
             return new
         if hasattr(s, 'validate'):
             try:

--- a/test_schema.py
+++ b/test_schema.py
@@ -120,14 +120,21 @@ def test_dict():
         try:
             Schema({}).validate({'n': 5})
         except SchemaError as e:
-            assert e.args[0] == "wrong keys {} in {'n': 5}"
+            assert e.args[0] == "wrong keys 'n' in {'n': 5}"
             raise
     with SE:
         try:
-            Schema({'key': 5}).validate({'key': 5, 'n': 5})
+            Schema({'key': 5}).validate({'key': 5, 'bad': 5})
         except SchemaError as e:
-            assert e.args[0] in ["wrong keys {'key': 5} in {'key': 5, 'n': 5}",
-                                 "wrong keys {'key': 5} in {'n': 5, 'key': 5}"]
+            assert e.args[0] in ["wrong keys 'bad' in {'key': 5, 'bad': 5}",
+                                 "wrong keys 'bad' in {'bad': 5, 'key': 5}"]
+            raise
+    with SE:
+        try:
+            Schema({}).validate({'a': 5, 'b': 5})
+        except SchemaError as e:
+            assert e.args[0] in ["wrong keys 'a', 'b' in {'a': 5, 'b': 5}",
+                                 "wrong keys 'a', 'b' in {'b': 5, 'a': 5}"]
             raise
 
 


### PR DESCRIPTION
fixes #3 and #15. 

On top of original pull request https://github.com/halst/schema/pull/18 to improve messages for values, I made the error messages more clear when input contain unexpected keys, e.g.:

``` python
>>> Schema({'a':int}).validate({'a': 1, 'bad': 5, 'bad2':None})

Traceback (most recent call last):
...
SchemaError: wrong keys 'bad', 'bad2' in {'a': 1, 'bad': 5, 'bad2': None}
```

P.S. tried merging with  halst:master but the master currently seem partially broken as some tests are failing there even before my merge (probably connected to Optional() fix), so I'll leave the merging out for now...
