### PR TITLE
added nested prioritisation for dict validation

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -80,7 +80,10 @@ def priority(s):
     if type(s) is dict:
         return [5]
     if hasattr(s, 'validate'):
-        return [4] + priority(s._schema)
+        p = [4]
+        if hasattr(s, "_schema"):
+            p.extend(priority(s._schema))
+        return p
     if type(s) is type:
         return [3]
     if callable(s):

--- a/schema.py
+++ b/schema.py
@@ -76,17 +76,17 @@ class Use(object):
 def priority(s):
     """Return priority for a give object."""
     if type(s) in (list, tuple, set, frozenset):
-        return 6
+        return [6]
     if type(s) is dict:
-        return 5
+        return [5]
     if hasattr(s, 'validate'):
-        return 4
-    if issubclass(type(s), type):
-        return 3
+        return [4] + priority(s._schema)
+    if type(s) is type:
+        return [3]
     if callable(s):
-        return 2
+        return [2]
     else:
-        return 1
+        return [1]
 
 
 class Schema(object):


### PR DESCRIPTION
Consider the schema:

```
s = Schema({Optional('foo'): int, Optional(basestring): object})
```
Here we would like to have dict validation that ensures 'foo' is integer, but also allows any other extra, unvalidated items. It doesn't work though, because both schema keys have the same priority, and a 'foo' dict entry can be consumed by the Optional(basestring) schema.

This pull request contains a simple change so that prioritisation takes schema contents into account. For example, since a string instance would be used for validation before basestring (non-types before types), it follows that Optional(string instance) now takes precedence over Optional(basestring).

