### PR TITLE
Support defaults via Optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -225,6 +225,19 @@ You can mark a key as optional as follows:
     ...         Optional('occupation'): str}).validate({'name': 'Sam'})
     {'name': 'Sam'}
 
+``Optional`` keys can also carry a ``default``, to be used when no key in the
+data matches:
+
+.. code:: python
+
+    >>> from schema import Optional
+    >>> Schema({Optional('color', default='blue'): str,
+    ...         str: str}).validate({'texture': 'furry'})
+    {'color': 'blue', 'texture': 'furry'}
+
+Defaults are used verbatim, not passed through any validators specified in the
+value.
+
 **schema** has classes ``And`` and ``Or`` that help validating several schemas
 for the same data:
 

--- a/schema.py
+++ b/schema.py
@@ -155,7 +155,7 @@ class Schema(object):
             defaults = set(k for k in s if type(k) is Optional and
                            hasattr(k, 'default')) - covered_optionals
             for default in defaults:
-                new[default.name] = default.default
+                new[default.key] = default.default
 
             return new
         if flavor == TYPE:
@@ -199,9 +199,11 @@ class Optional(Schema):
         default = kwargs.pop('default', MARKER)
         super(Optional, self).__init__(*args, **kwargs)
         if default is not MARKER:
-            # TODO: If I can't figure out a key name for myself, freak out.
+            # See if I can come up with a static key to use for myself:
+            if priority(self._schema) != COMPARABLE:
+                raise TypeError(
+                        'Optional keys with defaults must have simple, '
+                        'predictable values, like literal strings or ints. '
+                        '"%r" is too complex.' % (self._schema,))
             self.default = default
-
-    @property
-    def name(self):
-        return self._schema
+            self.key = self._schema

--- a/schema.py
+++ b/schema.py
@@ -128,6 +128,8 @@ class Schema(object):
                             raise
                         else:
                             coverage.add(skey)
+                            if type(skey) is not Optional:
+                                coverage.add(skey)
                             valid = True
                             break
                 if valid:
@@ -136,7 +138,6 @@ class Schema(object):
                     if x is not None:
                         raise SchemaError(['invalid value for key %r' % key] +
                                           x.autos, [e] + x.errors)
-            coverage = set(k for k in coverage if type(k) is not Optional)
             required = set(k for k in s if type(k) is not Optional)
             if coverage != required:
                 raise SchemaError('missed keys %r' % (required - coverage), e)

--- a/schema.py
+++ b/schema.py
@@ -79,9 +79,9 @@ def priority(s):
         return 6
     if type(s) is dict:
         return 5
-    if hasattr(s, 'validate'):
-        return 4
     if issubclass(type(s), type):
+        return 4
+    if hasattr(s, 'validate'):
         return 3
     if callable(s):
         return 2
@@ -146,6 +146,11 @@ class Schema(object):
                 raise SchemaError('wrong keys %s in %r' % (s_wrong_keys, data),
                                   e)
             return new
+        if issubclass(type(s), type):
+            if isinstance(data, s):
+                return data
+            else:
+                raise SchemaError('%r should be instance of %r' % (data, s), e)
         if hasattr(s, 'validate'):
             try:
                 return s.validate(data)
@@ -154,11 +159,6 @@ class Schema(object):
             except BaseException as x:
                 raise SchemaError('%r.validate(%r) raised %r' % (s, data, x),
                                   self._error)
-        if issubclass(type(s), type):
-            if isinstance(data, s):
-                return data
-            else:
-                raise SchemaError('%r should be instance of %r' % (data, s), e)
         if callable(s):
             f = s.__name__
             try:

--- a/test_schema.py
+++ b/test_schema.py
@@ -155,6 +155,17 @@ def test_dict_optional_keys():
     assert Schema({basestring: 1, Optional('b'): 2}).validate({'a': 1, 'b': 2}) == {'a': 1, 'b': 2}
 
 
+def test_dict_optional_defaults():
+    # Optionals fill out their defaults:
+    assert Schema({Optional('a', default=1): 11,
+                   Optional('b', default=2): 22}).validate({'a': 11}) == {'a': 11, 'b': 2}
+
+    # Optionals take precedence over types. Here, the "a" is served by the
+    # Optional:
+    assert Schema({Optional('a', default=1): 11,
+                   basestring: 22}).validate({'b': 22}) == {'a': 1, 'b': 22}
+
+
 def test_complex():
     s = Schema({'<file>': And([Use(open)], lambda l: len(l)),
                 '<path>': os.path.exists,

--- a/test_schema.py
+++ b/test_schema.py
@@ -165,6 +165,9 @@ def test_dict_optional_defaults():
     assert Schema({Optional('a', default=1): 11,
                    basestring: 22}).validate({'b': 22}) == {'a': 1, 'b': 22}
 
+    with raises(TypeError):
+        Optional(And(str, Use(int)), default=7)
+
 
 def test_complex():
     s = Schema({'<file>': And([Use(open)], lambda l: len(l)),

--- a/test_schema.py
+++ b/test_schema.py
@@ -151,6 +151,8 @@ def test_dict_optional_keys():
     assert Schema({'a': 1, Optional('b'): 2}).validate({'a': 1}) == {'a': 1}
     assert Schema({'a': 1, Optional('b'): 2}).validate(
             {'a': 1, 'b': 2}) == {'a': 1, 'b': 2}
+    # Make sure Optionals are favored over types:
+    assert Schema({basestring: 1, Optional('b'): 2}).validate({'a': 1, 'b': 2}) == {'a': 1, 'b': 2}
 
 
 def test_complex():

--- a/test_schema.py
+++ b/test_schema.py
@@ -152,7 +152,8 @@ def test_dict_optional_keys():
     assert Schema({'a': 1, Optional('b'): 2}).validate(
             {'a': 1, 'b': 2}) == {'a': 1, 'b': 2}
     # Make sure Optionals are favored over types:
-    assert Schema({basestring: 1, Optional('b'): 2}).validate({'a': 1, 'b': 2}) == {'a': 1, 'b': 2}
+    assert Schema({basestring: 1,
+                   Optional('b'): 2}).validate({'a': 1, 'b': 2}) == {'a': 1, 'b': 2}
 
 
 def test_dict_optional_defaults():


### PR DESCRIPTION
This lets us insert default values for missing dict keys. I independently arrived at this API before seeing that it's also a leading contender in https://github.com/keleshev/schema/pull/19, so it's at least unsurprising for 2 people. :-)

I had to do a minor twiddle of prioritization so that more generic keys like `str` wouldn't eat the Optionals' lunch, but that shouldn't affect any conceivable non-crashing use case. (See one of the commit messages for details.)