### PR TITLE
Prioritize Optionals based on one level of depth traversal. Close #44, #45.

### DIFF
--- a/test_schema.py
+++ b/test_schema.py
@@ -156,6 +156,13 @@ def test_dict_optional_keys():
                    Optional('b'): 2}).validate({'a': 1, 'b': 2}) == {'a': 1, 'b': 2}
 
 
+def test_delegated_priority():
+    """Make sure compound, instance-delegated priorities work."""
+    # Optional('a') should take precedence, because it's more specific.
+    assert Schema({Optional(str): 1,
+                   Optional('a'): 2}).validate({'a': 2}) == {'a': 2}
+
+
 def test_dict_optional_defaults():
     # Optionals fill out their defaults:
     assert Schema({Optional('a', default=1): 11,


### PR DESCRIPTION
This enables the common pattern in which there's a 'foo' key with a default and we also take arbitrary other, optional str keys.

We turn priority() into a delegating "generic function", like len().

This lays the groundwork to go deeper--with any "flavor", not just Optionals. First, we'd want to refactor Schema.validate() so it constructs actual Schema subclasses all the time rather than handling many cases inline. For sets, for example, it would construct an Iterable, and Iterable.priority() would know how to tunnel one level inside itself to return a compound priority. Then we could prioritize Optional((1, 0)) over Optional((int,)). The behavior of And() and Or() (and iterables) are up for grabs: perhaps go with the priority of the most specific item inside?