### PR TITLE
setup.py: Decode README.rst as utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup
 
+import codecs
 import schema
 
 
@@ -13,7 +14,7 @@ setup(
     keywords="schema json validation",
     url="http://github.com/halst/schema",
     py_modules=['schema'],
-    long_description=open('README.rst').read(),
+    long_description=codecs.open('README.rst', 'r', 'utf-8').read(),
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Topic :: Utilities",


### PR DESCRIPTION
If LANG was not set on python3, opening this file (which happens when
installing) would fail because the README.rst contains non-ascii
characters. Using `codecs` we can explicitly decode it as utf-8.

Fixes #68