### PR TITLE
Fix reliance on `__name__` of callables, fixes #56

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -70,7 +70,7 @@ class Use(object):
         except SchemaError as x:
             raise SchemaError([None] + x.autos, [self._error] + x.errors)
         except BaseException as x:
-            f = self._callable.__name__
+            f = callable_str(self._callable)
             raise SchemaError('%s(%r) raised %r' % (f, data, x), self._error)
 
 
@@ -176,7 +176,7 @@ class Schema(object):
                 raise SchemaError('%r.validate(%r) raised %r' % (s, data, x),
                                   self._error)
         if flavor == CALLABLE:
-            f = s.__name__
+            f = callable_str(s)
             try:
                 if s(data):
                     return data
@@ -211,3 +211,9 @@ class Optional(Schema):
                     '"%r" is too complex.' % (self._schema,))
             self.default = default
             self.key = self._schema
+
+
+def callable_str(callable_):
+    if hasattr(callable_, '__name__'):
+        return callable_.__name__
+    return str(callable_)

--- a/schema.py
+++ b/schema.py
@@ -70,7 +70,7 @@ class Use(object):
         except SchemaError as x:
             raise SchemaError([None] + x.autos, [self._error] + x.errors)
         except BaseException as x:
-            f = callable_str(self._callable)
+            f = _callable_str(self._callable)
             raise SchemaError('%s(%r) raised %r' % (f, data, x), self._error)
 
 
@@ -176,7 +176,7 @@ class Schema(object):
                 raise SchemaError('%r.validate(%r) raised %r' % (s, data, x),
                                   self._error)
         if flavor == CALLABLE:
-            f = callable_str(s)
+            f = _callable_str(s)
             try:
                 if s(data):
                     return data
@@ -213,7 +213,7 @@ class Optional(Schema):
             self.key = self._schema
 
 
-def callable_str(callable_):
+def _callable_str(callable_):
     if hasattr(callable_, '__name__'):
         return callable_.__name__
     return str(callable_)

--- a/test_schema.py
+++ b/test_schema.py
@@ -1,5 +1,6 @@
 from __future__ import with_statement
 from collections import defaultdict, namedtuple
+from operator import methodcaller
 import os
 
 from pytest import raises
@@ -383,8 +384,18 @@ def test_missing_keys_exception_with_non_str_dict_keys():
         try:
             Schema({1: 'x'}).validate(dict())
         except SchemaError as e:
-            assert (e.args[0] ==
-                    "Missing keys: 1")
+            assert e.args[0] == "Missing keys: 1"
+            raise
+
+
+def test_issue_56_cant_rely_on_callables_to_have_name():
+    s = Schema(methodcaller('endswith', '.csv'))
+    assert s.validate('test.csv') == 'test.csv'
+    with SE:
+        try:
+            s.validate('test.py')
+        except SchemaError as e:
+            assert "operator.methodcaller" in e.args[0]
             raise
 
 


### PR DESCRIPTION
Fixes #56.