### PR TITLE
bump version to 0.3.2.dev0 as 0.3.1 was released long ago

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.1'
+__version__ = '0.3.2.dev0'
 
 
 class SchemaError(Exception):


### PR DESCRIPTION
Currently when you install the latest development version via
e.g. pip install 'git+https://github.com/keleshev/schema.git'
you end up with a schema package that still advertises itself
as version 0.3.1, even though it's a later version.

Bumping the version to 0.3.2.dev0 makes it easier for users
to confirm whether a bug released in 0.3.1 has since been
fixed in master, as we can now inspect `schema.__version__`
and get a different value than the version with the bug.

I learned it's good practice to bump the version like this as the
next commit to master immediately after doing a release.