### PR TITLE
Include the test suite in the source distribution.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.rst LICENSE-MIT
+include README.rst LICENSE-MIT tox.ini test_schema.py


### PR DESCRIPTION
The test suite is useful for downstream packaging, hence it should be included in the tarballs uploaded to pypi.