### PR TITLE
add strict flag in Schema class to skip wrong key validation without wildcard

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -257,6 +257,19 @@ for the same data:
     >>> Schema(And(Or(int, float), lambda x: x > 0)).validate(3.1415)
     3.1415
 
+Extra Keys
+~~~~~~~~~~
+
+The ``Schema(...)`` parameter ``ignore_extra_keys`` do not validate extra keys and also do not return them after validation.
+
+.. code:: python
+
+    >>> schema = Schema({'name': str}, ignore_extra_keys=True)
+    >>> schema.validate({'name': 'Sam', 'age': '42'})
+    {'name': 'Sam'}
+
+Otherwise, any extra key raise a ``SchemaError``.
+
 User-friendly error reporting
 -------------------------------------------------------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -260,7 +260,7 @@ for the same data:
 Extra Keys
 ~~~~~~~~~~
 
-The ``Schema(...)`` parameter ``ignore_extra_keys`` do not validate extra keys and also do not return them after validation.
+The ``Schema(...)`` parameter ``ignore_extra_keys`` causes validation to ignore extra keys in a dictionary, and also to not return them after validating.
 
 .. code:: python
 
@@ -268,7 +268,8 @@ The ``Schema(...)`` parameter ``ignore_extra_keys`` do not validate extra keys a
     >>> schema.validate({'name': 'Sam', 'age': '42'})
     {'name': 'Sam'}
 
-Otherwise, any extra key raise a ``SchemaError``.
+If you would like any extra keys returned, use ``object: object`` as one of the key/value pairs, which will match any key and any value.
+Otherwise, extra keys will raise a ``SchemaError``.
 
 User-friendly error reporting
 -------------------------------------------------------------------------------

--- a/schema.py
+++ b/schema.py
@@ -96,10 +96,10 @@ def _priority(s):
 
 class Schema(object):
 
-    def __init__(self, schema, error=None, strict=True):
+    def __init__(self, schema, error=None, ignore_extra_keys=False):
         self._schema = schema
         self._error = error
-        self._strict = strict
+        self._ignore_extra_keys = ignore_extra_keys
 
     def __repr__(self):
         return '%s(%r)' % (self.__class__.__name__, self._schema)
@@ -142,7 +142,7 @@ class Schema(object):
                 missing_keys = required - coverage
                 s_missing_keys = ", ".join(repr(k) for k in missing_keys)
                 raise SchemaError('Missing keys: ' + s_missing_keys, e)
-            if self._strict and (len(new) != len(data)):
+            if not self._ignore_extra_keys and (len(new) != len(data)):
                 wrong_keys = set(data.keys()) - set(new.keys())
                 s_wrong_keys = ', '.join(repr(k) for k in sorted(wrong_keys,
                                                                  key=repr))

--- a/schema.py
+++ b/schema.py
@@ -96,9 +96,10 @@ def _priority(s):
 
 class Schema(object):
 
-    def __init__(self, schema, error=None):
+    def __init__(self, schema, error=None, strict=True):
         self._schema = schema
         self._error = error
+        self._strict = strict
 
     def __repr__(self):
         return '%s(%r)' % (self.__class__.__name__, self._schema)
@@ -141,7 +142,7 @@ class Schema(object):
                 missing_keys = required - coverage
                 s_missing_keys = ", ".join(repr(k) for k in missing_keys)
                 raise SchemaError('Missing keys: ' + s_missing_keys, e)
-            if len(new) != len(data):
+            if self._strict and (len(new) != len(data)):
                 wrong_keys = set(data.keys()) - set(new.keys())
                 s_wrong_keys = ', '.join(repr(k) for k in sorted(wrong_keys,
                                                                  key=repr))

--- a/test_schema.py
+++ b/test_schema.py
@@ -153,6 +153,11 @@ def test_dict_keys():
             {1: 3.14, 3.14: 1}) == {'1': 3, '3.14': 1}
 
 
+def test_no_strict_schema():
+    assert Schema({'key': 5}, strict=False).validate(
+            {'key': 5, 'bad': 4}) == {'key': 5}
+
+
 def test_dict_optional_keys():
     with SE: Schema({'a': 1, 'b': 2}).validate({'a': 1})
     assert Schema({'a': 1, Optional('b'): 2}).validate({'a': 1}) == {'a': 1}

--- a/test_schema.py
+++ b/test_schema.py
@@ -153,9 +153,14 @@ def test_dict_keys():
             {1: 3.14, 3.14: 1}) == {'1': 3, '3.14': 1}
 
 
-def test_no_strict_schema():
-    assert Schema({'key': 5}, strict=False).validate(
+def test_ignore_extra_keys():
+    assert Schema({'key': 5}, ignore_extra_keys=True).validate(
             {'key': 5, 'bad': 4}) == {'key': 5}
+
+
+def test_ignore_extra_keys_validation_and_return_keys():
+    assert Schema({'key': 5, object: object}, ignore_extra_keys=True).validate(
+            {'key': 5, 'bad': 4}) == {'key': 5, 'bad': 4}
 
 
 def test_dict_optional_keys():


### PR DESCRIPTION
To avoid `SchemaError` for validations with more keys of the schema:

```python
>>> Schema({'key', 'value'}, strict=False).validate({'key', 'value', 'foo': 'bar})
>>> {'key', 'value'}
```