### PR TITLE
Allow the error parameter string to contain string formatting parameters

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -52,7 +52,7 @@ class Or(And):
             except SchemaError as _x:
                 x = _x
         raise SchemaError(['%r did not validate %r' % (self, data)] + x.autos,
-                          [self._error] + x.errors)
+                          [self._error.format(data)] + x.errors)
 
 
 class Use(object):
@@ -69,10 +69,10 @@ class Use(object):
         try:
             return self._callable(data)
         except SchemaError as x:
-            raise SchemaError([None] + x.autos, [self._error] + x.errors)
+            raise SchemaError([None] + x.autos, [self._error.format(data)] + x.errors)
         except BaseException as x:
             f = _callable_str(self._callable)
-            raise SchemaError('%s(%r) raised %r' % (f, data, x), self._error)
+            raise SchemaError('%s(%r) raised %r' % (f, data, x), self._error.format(data))
 
 
 COMPARABLE, CALLABLE, VALIDATOR, TYPE, DICT, ITERABLE = range(6)
@@ -147,7 +147,7 @@ class Schema(object):
                 s_wrong_keys = ', '.join(repr(k) for k in sorted(wrong_keys,
                                                                  key=repr))
                 raise SchemaError('Wrong keys %s in %r' % (s_wrong_keys, data),
-                                  e)
+                                  e.format(data))
 
             # Apply default-having optionals that haven't been used:
             defaults = set(k for k in s if type(k) is Optional and
@@ -161,7 +161,7 @@ class Schema(object):
                 return data
             else:
                 raise SchemaError('%r should be instance of %r' %
-                                  (data, s.__name__), e)
+                                  (data, s.__name__), e.format(data))
         if flavor == VALIDATOR:
             try:
                 return s.validate(data)
@@ -169,7 +169,7 @@ class Schema(object):
                 raise SchemaError([None] + x.autos, [e] + x.errors)
             except BaseException as x:
                 raise SchemaError('%r.validate(%r) raised %r' % (s, data, x),
-                                  self._error)
+                                  self._error.format(data))
         if flavor == CALLABLE:
             f = _callable_str(s)
             try:
@@ -179,12 +179,12 @@ class Schema(object):
                 raise SchemaError([None] + x.autos, [e] + x.errors)
             except BaseException as x:
                 raise SchemaError('%s(%r) raised %r' % (f, data, x),
-                                  self._error)
+                                  self._error.format(data))
             raise SchemaError('%s(%r) should evaluate to True' % (f, data), e)
         if s == data:
             return data
         else:
-            raise SchemaError('%r does not match %r' % (s, data), e)
+            raise SchemaError('%r does not match %r' % (s, data), e.format(data))
 
 
 class Optional(Schema):


### PR DESCRIPTION
This PR adds a call to format on the `error` parameter before displaying it, passing the data into the formatter. This allows custom error messages to change from something like `"Invalid user id."` to `"Invalid user id: {}"`, which would display as `"Invalid user id: 9243"`.

Please let me know if I missed something somewhere.