### PR TITLE
Adding regular expression (regex) support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,8 +117,25 @@ this method on corresponding data as ``data = obj.validate(data)``. This method
 may raise ``SchemaError`` exception, which will tell ``Schema`` that that piece
 of data is invalid, otherwise—it will continue validating.
 
-As example, you can use ``Use`` for creating such objects. ``Use`` helps to use
-a function or type to convert a value while validating it:
+An example of "validatable" is ``Regex``, that tries to match a string or a
+buffer with the given regular expression (itself as a string, buffer or
+compiled regex ``SRE_Pattern``).
+
+.. code:: python
+
+    >>> from schema import Regex
+    >>> import re
+
+    >>> Regex(r'^foo').validate('foobar')
+    'foobar'
+
+    >>> Regex(r'^[A-Z]+$', flags=re.I).validate('those-dashes-dont-match')
+    Traceback (most recent call last):
+    ...
+    SchemaError: Regex('^[A-Z]+$', flags=re.IGNORECASE) does not match 'those-dashes-dont-match'
+
+For a more general case, you can use ``Use`` for creating such objects.
+``Use`` helps to use a function or type to convert a value while validating it:
 
 .. code:: python
 
@@ -267,8 +284,8 @@ User-friendly error reporting
 -------------------------------------------------------------------------------
 
 You can pass a keyword argument ``error`` to any of validatable classes
-(such as ``Schema``, ``And``, ``Or``, ``Use``) to report this error instead of
-a built-in one.
+(such as ``Schema``, ``And``, ``Or``, ``Regex``, ``Use``) to report this error
+instead of a built-in one.
 
 .. code:: python
 

--- a/schema.py
+++ b/schema.py
@@ -75,7 +75,7 @@ class Regex(object):
             else:
                 raise SchemaError('%r does not match %r' % (self, data), e)
         except TypeError:
-            raise SchemaError('%r should have a buffer interface' % data, e)
+            raise SchemaError('%r is not string nor buffer' % data, e)
 
 
 class Use(object):

--- a/schema.py
+++ b/schema.py
@@ -60,7 +60,6 @@ class Or(And):
 class Regex(object):
 
     def __init__(self, pattern, flags=0, error=None):
-        assert type(pattern) is str
         self._pattern = re.compile(pattern, flags=flags)
         self._error = error
 

--- a/schema.py
+++ b/schema.py
@@ -1,5 +1,7 @@
-__version__ = '0.5.0'
-__all__ = ['Schema', 'And', 'Or', 'Optional', 'SchemaError']
+import re
+
+__version__ = '0.5.0-dev'
+__all__ = ['Schema', 'And', 'Or', 'Regex', 'Optional', 'SchemaError']
 
 
 class SchemaError(Exception):
@@ -53,6 +55,24 @@ class Or(And):
                 x = _x
         raise SchemaError(['%r did not validate %r' % (self, data)] + x.autos,
                           [self._error] + x.errors)
+
+
+class Regex(object):
+    def __init__(self, pattern, flags=0, error=None):
+        assert type(pattern) is str
+        self._pattern = re.compile(pattern, flags=flags)
+        self._error = error
+
+    def __repr__(self):
+        return '%s(%r)' % (self.__class__.__name__, self._pattern)
+
+    def validate(self, data):
+        e = self._error
+
+        if self._pattern.search(data):
+            return data
+        else:
+            raise SchemaError('%r does not match %r' % (self, data), e)
 
 
 class Use(object):

--- a/schema.py
+++ b/schema.py
@@ -58,6 +58,7 @@ class Or(And):
 
 
 class Regex(object):
+
     def __init__(self, pattern, flags=0, error=None):
         assert type(pattern) is str
         self._pattern = re.compile(pattern, flags=flags)

--- a/schema.py
+++ b/schema.py
@@ -70,10 +70,13 @@ class Regex(object):
     def validate(self, data):
         e = self._error
 
-        if self._pattern.search(data):
-            return data
-        else:
-            raise SchemaError('%r does not match %r' % (self, data), e)
+        try:
+            if self._pattern.search(data):
+                return data
+            else:
+                raise SchemaError('%r does not match %r' % (self, data), e)
+        except TypeError:
+            raise SchemaError('%r should have a buffer interface' % data, e)
 
 
 class Use(object):

--- a/schema.py
+++ b/schema.py
@@ -58,13 +58,22 @@ class Or(And):
 
 
 class Regex(object):
+    # Map all flags bits to a more readable description
+    NAMES = ['re.ASCII', 're.DEBUG', 're.VERBOSE', 're.UNICODE', 're.DOTALL',
+             're.MULTILINE', 're.LOCALE', 're.IGNORECASE', 're.TEMPLATE']
 
-    def __init__(self, pattern, flags=0, error=None):
-        self._pattern = re.compile(pattern, flags=flags)
+    def __init__(self, pattern_str, flags=0, error=None):
+        self._pattern_str = pattern_str
+        self._flags_names = [Regex.NAMES[i] for i, f in  # Name for each bit
+                             enumerate('{0:09b}'.format(flags)) if f != '0']
+        self._pattern = re.compile(pattern_str, flags=flags)
         self._error = error
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, self._pattern)
+        return '%s(%r, flags=%s)' % (
+            self.__class__.__name__,
+            self._pattern_str,
+            ' + '.join(self._flags_names) if self._flags_names else '0')
 
     def validate(self, data):
         e = self._error

--- a/schema.py
+++ b/schema.py
@@ -64,16 +64,21 @@ class Regex(object):
 
     def __init__(self, pattern_str, flags=0, error=None):
         self._pattern_str = pattern_str
-        self._flags_names = [Regex.NAMES[i] for i, f in  # Name for each bit
-                             enumerate('{0:09b}'.format(flags)) if f != '0']
+        flags_list = [Regex.NAMES[i] for i, f in  # Name for each bit
+                      enumerate('{0:09b}'.format(flags)) if f != '0']
+
+        if flags_list:
+            self._flags_names = ', flags=' + '|'.join(flags_list)
+        else:
+            self._flags_names = ''
+
         self._pattern = re.compile(pattern_str, flags=flags)
         self._error = error
 
     def __repr__(self):
-        return '%s(%r, flags=%s)' % (
-            self.__class__.__name__,
-            self._pattern_str,
-            ' + '.join(self._flags_names) if self._flags_names else '0')
+        return '%s(%r%s)' % (
+            self.__class__.__name__, self._pattern_str, self._flags_names
+        )
 
     def validate(self, data):
         e = self._error

--- a/test_schema.py
+++ b/test_schema.py
@@ -75,6 +75,8 @@ def test_or():
 def test_regex():
     assert Regex(r'foo').validate('afoot')
     with SE: assert Regex(r'bar').validate('afoot')
+    assert Regex(r'^[a-z]+$').validate('letters')
+    with SE: assert Regex(r'^[a-z]+$').validate('letters and spaces')
 
 
 def test_validate_list():

--- a/test_schema.py
+++ b/test_schema.py
@@ -5,7 +5,7 @@ import os
 
 from pytest import raises
 
-from schema import Schema, Use, And, Or, Optional, SchemaError
+from schema import Schema, Use, And, Or, Regex, Optional, SchemaError
 
 
 try:
@@ -70,6 +70,11 @@ def test_or():
     with SE: Or(int, dict).validate('hai')
     assert Or(int).validate(4)
     with SE: Or().validate(2)
+
+
+def test_regex():
+    assert Regex(r'foo').validate('afoot')
+    with SE: assert Regex(r'bar').validate('afoot')
 
 
 def test_validate_list():

--- a/test_schema.py
+++ b/test_schema.py
@@ -78,6 +78,9 @@ def test_regex():
     assert Regex(r'^[a-z]+$').validate('letters')
     with SE: assert Regex(r'^[a-z]+$').validate('letters and spaces')
 
+    assert Schema({Regex(r'^foo'): str}).validate({'fookey': 'value'})
+    with SE: assert Schema({Regex(r'^foo'): str}).validate({'barkey': 'value'})
+
 
 def test_validate_list():
     assert Schema([1, 0]).validate([1, 0, 1, 1]) == [1, 0, 1, 1]

--- a/test_schema.py
+++ b/test_schema.py
@@ -81,6 +81,9 @@ def test_regex():
     assert Schema({Regex(r'^foo'): str}).validate({'fookey': 'value'})
     with SE: assert Schema({Regex(r'^foo'): str}).validate({'barkey': 'value'})
 
+    with SE: assert Regex(r'bar').validate(1)
+    with SE: assert Regex(r'bar').validate({})
+
 
 def test_validate_list():
     assert Schema([1, 0]).validate([1, 0, 1, 1]) == [1, 0, 1, 1]

--- a/test_schema.py
+++ b/test_schema.py
@@ -2,16 +2,17 @@ from __future__ import with_statement
 from collections import defaultdict, namedtuple
 from operator import methodcaller
 import os
+import re
+import sys
 
 from pytest import raises
 
 from schema import Schema, Use, And, Or, Regex, Optional, SchemaError
 
 
-try:
-    basestring
-except NameError:
+if sys.version_info[0] == 3:
     basestring = str  # Python 3 does not have basestring
+    unicode = str  # Python 3 does not have unicode
 
 
 SE = raises(SchemaError)
@@ -73,16 +74,38 @@ def test_or():
 
 
 def test_regex():
-    assert Regex(r'foo').validate('afoot')
-    with SE: assert Regex(r'bar').validate('afoot')
-    assert Regex(r'^[a-z]+$').validate('letters')
-    with SE: assert Regex(r'^[a-z]+$').validate('letters and spaces')
+    # Simple case: validate string
+    assert Regex(r'foo').validate('afoot') == 'afoot'
+    with SE: Regex(r'bar').validate('afoot')
 
-    assert Schema({Regex(r'^foo'): str}).validate({'fookey': 'value'})
-    with SE: assert Schema({Regex(r'^foo'): str}).validate({'barkey': 'value'})
+    # More complex case: validate string
+    assert Regex(r'^[a-z]+$').validate('letters') == 'letters'
+    with SE:
+        Regex(r'^[a-z]+$').validate('letters + spaces') == 'letters + spaces'
 
-    with SE: assert Regex(r'bar').validate(1)
-    with SE: assert Regex(r'bar').validate({})
+    # Validate dict key
+    assert (Schema({Regex(r'^foo'): str})
+            .validate({'fookey': 'value'}) == {'fookey': 'value'})
+    with SE: Schema({Regex(r'^foo'): str}).validate({'barkey': 'value'})
+
+    # Validate dict value
+    assert (Schema({str: Regex(r'^foo')}).validate({'key': 'foovalue'}) ==
+            {'key': 'foovalue'})
+    with SE: Schema({str: Regex(r'^foo')}).validate({'key': 'barvalue'})
+
+    # Error if the value does not have a buffer interface
+    with SE: Regex(r'bar').validate(1)
+    with SE: Regex(r'bar').validate({})
+    with SE: Regex(r'bar').validate([])
+    with SE: Regex(r'bar').validate(None)
+
+    # Validate that the pattern has a buffer interface
+    assert Regex(re.compile(r'foo')).validate('foo') == 'foo'
+    assert Regex(unicode('foo')).validate('foo') == 'foo'
+    with raises(TypeError): Regex(1).validate('bar')
+    with raises(TypeError): Regex({}).validate('bar')
+    with raises(TypeError): Regex([]).validate('bar')
+    with raises(TypeError): Regex(None).validate('bar')
 
 
 def test_validate_list():


### PR DESCRIPTION
Hi,

Here is a proposition to add regex support to the library, with the use of `re.pattern.search` method from the Python core regex library (support was tested on python 2.6.9, 2.7.12, 3.3.0, 3.4.3, 3.5.2, pypy-5.3 and pypy3-2.4.0).

Four simple test cases were added as well.

Note that support for python 3.2 was not tested because of an issue with tox and virtualenv: https://github.com/travis-ci/travis-ci/issues/5517