### PR TITLE
Show a key error if a dict error happens

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -210,7 +210,8 @@ You can specify keys as schemas too:
     ...                   10: 'not None here'})
     Traceback (most recent call last):
     ...
-    SchemaError: None does not match 'not None here'
+    SchemaError: Key '10' error:
+    None does not match 'not None here'
 
 This is useful if you want to check certain key-values, but don't care
 about other:
@@ -261,7 +262,8 @@ for the same data:
     >>> Schema({'password': And(str, lambda s: len(s) > 6)}).validate({'password': 'hai'})
     Traceback (most recent call last):
     ...
-    SchemaError: <lambda>('hai') should evaluate to True
+    SchemaError: Key 'password' error:
+    <lambda>('hai') should evaluate to True
 
     >>> Schema(And(Or(int, float), lambda x: x > 0)).validate(3.1415)
     3.1415

--- a/schema.py
+++ b/schema.py
@@ -237,10 +237,15 @@ class Schema(object):
                     except SchemaError:
                         pass
                     else:
-                        nvalue = Schema(svalue, error=e).validate(value)
-                        new[nkey] = nvalue
-                        coverage.add(skey)
-                        break
+                        try:
+                            nvalue = Schema(svalue, error=e).validate(value)
+                        except SchemaError as x:
+                            k = "Key %s error:" % nkey
+                            raise SchemaError([k] + x.autos, [e] + x.errors)
+                        else:
+                            new[nkey] = nvalue
+                            coverage.add(skey)
+                            break
             required = set(k for k in s if type(k) is not Optional)
             if not required.issubset(coverage):
                 missing_keys = required - coverage

--- a/schema.py
+++ b/schema.py
@@ -240,7 +240,7 @@ class Schema(object):
                         try:
                             nvalue = Schema(svalue, error=e).validate(value)
                         except SchemaError as x:
-                            k = "Key %s error:" % nkey
+                            k = "Key '%s' error:" % nkey
                             raise SchemaError([k] + x.autos, [e] + x.errors)
                         else:
                             new[nkey] = nvalue

--- a/test_schema.py
+++ b/test_schema.py
@@ -244,11 +244,11 @@ def test_dict_key_error():
     try:
         Schema({'k': int}).validate({'k': 'x'})
     except SchemaError as e:
-        assert e.code == "Key k error:\n'x' should be instance of 'int'"
+        assert e.code == "Key 'k' error:\n'x' should be instance of 'int'"
     try:
         Schema({'k': {'k2': int}}).validate({'k': {'k2': 'x'}})
     except SchemaError as e:
-        assert e.code == "Key k error:\nKey k2 error:\n'x' should be instance of 'int'"
+        assert e.code == "Key 'k' error:\nKey 'k2' error:\n'x' should be instance of 'int'"
     try:
         Schema({'k': {'k2': int}}, error='k2 should be int').validate({'k': {'k2': 'x'}})
     except SchemaError as e:

--- a/test_schema.py
+++ b/test_schema.py
@@ -240,6 +240,21 @@ def test_dict_subtypes():
     # is dropped!
 
 
+def test_dict_key_error():
+    try:
+        Schema({'k': int}).validate({'k': 'x'})
+    except SchemaError as e:
+        assert e.code == "Key k error:\n'x' should be instance of 'int'"
+    try:
+        Schema({'k': {'k2': int}}).validate({'k': {'k2': 'x'}})
+    except SchemaError as e:
+        assert e.code == "Key k error:\nKey k2 error:\n'x' should be instance of 'int'"
+    try:
+        Schema({'k': {'k2': int}}, error='k2 should be int').validate({'k': {'k2': 'x'}})
+    except SchemaError as e:
+        assert e.code == 'k2 should be int'
+
+
 def test_complex():
     s = Schema({'<file>': And([Use(open)], lambda l: len(l)),
                 '<path>': os.path.exists,

--- a/test_schema.py
+++ b/test_schema.py
@@ -248,7 +248,8 @@ def test_dict_key_error():
     try:
         Schema({'k': {'k2': int}}).validate({'k': {'k2': 'x'}})
     except SchemaError as e:
-        assert e.code == "Key 'k' error:\nKey 'k2' error:\n'x' should be instance of 'int'"
+        code = "Key 'k' error:\nKey 'k2' error:\n'x' should be instance of 'int'"
+        assert e.code == code
     try:
         Schema({'k': {'k2': int}}, error='k2 should be int').validate({'k': {'k2': 'x'}})
     except SchemaError as e:


### PR DESCRIPTION
I added a key error because if a dict is huge, it's hard to find what key error happen