### PR TITLE
Fix reference count issue for Or's objects.

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -107,17 +107,17 @@ class Or(And):
         :param data: data to be validated by provided schema.
         :return: return validated data if not validation
         """
-        x = SchemaError([], [])
+        autos, errors = [], []
         for s in [self._schema(s, error=self._error,
                                ignore_extra_keys=self._ignore_extra_keys)
                   for s in self._args]:
             try:
                 return s.validate(data)
             except SchemaError as _x:
-                x = _x
-        raise SchemaError(['%r did not validate %r' % (self, data)] + x.autos,
+                autos, errors = _x.autos, _x.errors
+        raise SchemaError(['%r did not validate %r' % (self, data)] + autos,
                           [self._error.format(data) if self._error else None] +
-                          x.errors)
+                          errors)
 
 
 class Regex(object):


### PR DESCRIPTION
In Python 3, when assign an exception instance (i.e. _x) to different name (i.e. x) in a local scope, 
A traceback object created and the tb_frame attribute of it refer to the frame of this scope.


Here's an example that demonstrate the issue:
```
>>> import sys
>>> from schema import And, Or, Schema, SchemaError
>>>
>>> s = Schema(And(Or(int, float), lambda x: x > 0))
>>> sys.getrefcount(s)
2
>>> # Or's 1st argument - exception instance (i.e. _x) is not assigned to local name (i.e.  x)
>>> s.validate(10)  
10
>>> sys.getrefcount(s)
2
>>> # Or's 2nd argument - exception instance (i.e. _x) assigned to local name (i.e.  x).
>>> s.validate(3.1415)  
3.1415
>>> sys.getrefcount(s)
3
>>> try:
        # invalid - exception instance (i.e. _x ) assigned to local name (i.e.  x ).
...      s.validate('10') 
... except SchemaError as e:
...      print(e)
Or(<class 'int'>, <class 'float'>) did not validate '10'
'10' should be instance of 'float'
>>> sys.getrefcount(s)
4
>>> sys.getrefcount(s._schema)
6
s._schema
And(Or(<class 'int'>, <class 'float'>), <function <lambda> at 0x0000013170CFA8C8>)
```
Here's another example using weakref:
```
>>> import weakref
>>> from schema import Or, Schema
>>>
>>> s = Schema(Or(int, float))
>>> r = weakref.ref(s)
>>> s is r()
True
>>> s.validate(3)
3
>>> del s
>>> r() is None
True
>>>
>>> s = Schema(Or(int, float))
>>> r = weakref.ref(s)
>>> s is r()
True
>>> s.validate(3.1)
3.1
>>> del s
>>> r() is None
False
>>> r() is None
False
>>> r() is None
>>> False
>>> r() is None
False
```
