### PR TITLE
Fix callable check under PyPy2

### DIFF
--- a/test_schema.py
+++ b/test_schema.py
@@ -6,8 +6,9 @@ import os
 import re
 import sys
 import copy
+import platform
 
-from pytest import raises
+from pytest import raises, mark
 
 from schema import (Schema, Use, And, Or, Regex, Optional, Const,
                     SchemaError, SchemaWrongKeyError,
@@ -507,6 +508,8 @@ def test_missing_keys_exception_with_non_str_dict_keys():
             raise
 
 
+# PyPy does have a __name__ attribute for its callables.
+@mark.skipif(platform.python_implementation() == 'PyPy')
 def test_issue_56_cant_rely_on_callables_to_have_name():
     s = Schema(methodcaller('endswith', '.csv'))
     assert s.validate('test.csv') == 'test.csv'

--- a/test_schema.py
+++ b/test_schema.py
@@ -509,7 +509,8 @@ def test_missing_keys_exception_with_non_str_dict_keys():
 
 
 # PyPy does have a __name__ attribute for its callables.
-@mark.skipif(platform.python_implementation() == 'PyPy')
+@mark.skipif(platform.python_implementation() == 'PyPy',
+             reason='Running on PyPy')
 def test_issue_56_cant_rely_on_callables_to_have_name():
     s = Schema(methodcaller('endswith', '.csv'))
     assert s.validate('test.csv') == 'test.csv'


### PR DESCRIPTION
With PyPy (at least version 2.7.3), methodcaller generated callables do have a __name__ attribute, so _callable_str() will not attempt to stringify it making this unit fail.