### PR TITLE
Remove ITERABLE type validating.

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -249,7 +249,6 @@ class Schema(object):
         i = self._ignore_extra_keys
         flavor = _priority(s)
         if flavor == ITERABLE:
-            data = Schema(type(s), error=e).validate(data)
             o = Or(*s, error=e, schema=Schema, ignore_extra_keys=i)
             return type(data)(o.validate(d) for d in data)
         if flavor == DICT:


### PR DESCRIPTION
There's no need to automatically type check ITERABLE flavours when this can be done by the user. 
The reason this is needed is because different iterables can often be treated the same way.
For example, the default JSON encoder accepts both tuples and lists as array types.
Creating a schema with either of them will result in the validation failing if the other is passed instead.