### PR TITLE
Schema Composition (Do Not Merge)

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -51,7 +51,7 @@ def compose(*schemas, **kwargs):
 
     Notes
     -----
-    The composition of schema types is handled in four cases:
+    The composition of schema types is handled in three cases:
 
     1. All are dictionaries.
 
@@ -61,10 +61,10 @@ def compose(*schemas, **kwargs):
 
        * All schemas are merged into a single iterable schema in the order they were passed into ``compose``.
 
-    4. There is a combination of different schema types.
+    3. There is a combination of different schema types.
 
        * A type error is raised if dictionary and iterable type schemas are composed.
-       * Any other combination of schema types are merged under one ``And`` validator.
+       * Any other combination of schema types are joined using a ``function(*schemas)`` (defaults to ``And``).
     """
     join = kwargs.get("join", And)
     schemas = [s._schema if isinstance(s, Schema) else s for s in schemas]

--- a/schema.py
+++ b/schema.py
@@ -55,16 +55,20 @@ def compose(*schemas, **kwargs):
 
     1. All are dictionaries.
 
-       * The schemas are merged together into one dictionary schema where shared keys are recursively composed.
+       * The schemas are merged together into one dictionary schema where shared keys
+       are recursively composed.
 
     2. All are iterables.
 
-       * All schemas are merged into a single iterable schema in the order they were passed into ``compose``.
+       * All schemas are merged into a single iterable schema in the order they were
+       passed into ``compose``.
 
     3. There is a combination of different schema types.
 
        * A type error is raised if dictionary and iterable type schemas are composed.
-       * Any other combination of schema types are joined using a ``function(*schemas)`` (defaults to ``And``).
+
+       * Any other combination of schema types are joined using a ``function(*schemas)``
+       (defaults to ``And``).
     """
     join = kwargs.get("join", And)
     schemas = [s._schema if isinstance(s, Schema) else s for s in schemas]

--- a/schema.py
+++ b/schema.py
@@ -30,7 +30,7 @@ def compose(*schemas, **kwargs):
     >>> s1 = Schema({"x": {"a": int}})
     >>> s2 = Schema({"x": {"b": str}})
     >>> s1_and_s2 = compose(s1, s2)
-    assert s1_and_s2.is_valid({"x": {"a": 3, "b": "hello!"}})
+    >>> assert s1_and_s2.is_valid({"x": {"a": 3, "b": "hello!"}})
 
     >>> s1 = Schema([int, str])
     >>> s2 = Schema([float])


### PR DESCRIPTION
# Summary

Closes #168 

With the `compose` function two or more schemas can be merged into one. The composition of schema types is handled in three cases:

1. All are dictionaries.
   * The schemas are merged together into one dictionary schema where shared keys are recursively composed.
2. All are iterables.
   * All schemas are merged into a single iterable schema in the order they were passed into ``compose``.
3. There is a combination of different schema types.
   * A type error is raised if dictionary and iterable type schemas are composed.
   * Any other combination of schema types are joined using a ``function(*schemas)`` (defaults to ``And``).

# Examples

Compose two schemas together using the default reducer.

```python
s1 = Schema({"a": int, "b": int})
s2 = Schema({"b": float})
s3 = compose(s2, s1) # note choice of order
assert s3.is_valid({"a": 1, "b":, 2.0})
```

Compose two schemas using a "validator" reducer where the resulting schema requires all conditions from the given schemas to be true. In this particular case the merged schema validates when given a string that is lowercase.

```python
s1 = Schema(str)
s2 = Schema(lambda s: s.lower() == s)
and_reducer = Use(lambda schemas: And(*schemas))
s3 = compose(s1, s2, reduce=and_reducer)
assert s3.is_valid("hello world!")
assert not s3.is_valid("Hello World!")
```

The following example demonstrates how to form more complex reducers by using an `Or` validator to combine to combine others (including the `and_reducer`) from the example above.

```python
import functools, operator
s1 = Schema({"a": [int], "b": str})
s2 = Schema({"a": [float], "b": lambda s: s.lower() == s})
join_lists = lambda schemas: functools.reduce(operator.add, schemas, [])
list_reducer = And([list], Use(join_lists))
reducer = Or(list_reducer, and_reducer)
s3 = compose(s1, s2, reduce=reducer)
assert s3.is_valid({"a": [1, 2.0], "b": "hello world"})
```

# Gist

https://gist.github.com/rmorshea/1e8d00dbd9f583f763837c47d3910c25

# Todo

+ Update README
+ Add tests.