### PR TITLE
Allow exclusive or in a dict schema

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -268,6 +268,20 @@ data matches:
 Defaults are used verbatim, not passed through any validators specified in the
 value.
 
+In a dictionary, you can also combine two keys in a "one or the other" manner. To do
+so, use the `Or` class as a key:
+
+.. code:: python
+    from schema import Or, Schema
+    schema = Schema({
+        Or("key1", "key2", only_one=True): str
+    })
+
+    schema.validate({"key1": "test"}) # Ok
+    schema.validate({"key1": "test", "key2": "test"}) # SchemaWrongKeyError
+
+    
+
 You can mark a key as forbidden as follows:
 
 .. code:: python

--- a/schema.py
+++ b/schema.py
@@ -71,6 +71,7 @@ class And(object):
     """
     Utility function to combine validation directives in AND Boolean fashion.
     """
+
     def __init__(self, *args, **kw):
         self._args = args
         if not set(kw).issubset({'error', 'schema', 'ignore_extra_keys'}):
@@ -102,6 +103,15 @@ class And(object):
 class Or(And):
     """Utility function to combine validation directives in a OR Boolean
     fashion."""
+
+    def __init__(self, *args, **kwargs):
+        self.only_one = kwargs.pop('only_one', False)
+        self.reset()
+        super(Or, self).__init__(*args, **kwargs)
+
+    def reset(self):
+        self.got_one = False
+
     def validate(self, data):
         """
         Validate data using sub defined schema/expressions ensuring at least
@@ -114,7 +124,11 @@ class Or(And):
                                ignore_extra_keys=self._ignore_extra_keys)
                   for s in self._args]:
             try:
-                return s.validate(data)
+                validation = s.validate(data)
+                if self.got_one and self.only_one:
+                    break
+                self.got_one = True
+                return validation
             except SchemaError as _x:
                 autos, errors = _x.autos, _x.errors
         raise SchemaError(['%r did not validate %r' % (self, data)] + autos,
@@ -170,6 +184,7 @@ class Use(object):
     For more general use cases, you can use the Use class to transform
     the data while it is being validate.
     """
+
     def __init__(self, callable_, error=None):
         if not callable(callable_):
             raise TypeError('Expected a callable, not %r' % callable_)
@@ -217,6 +232,7 @@ class Schema(object):
     Entry point of the library, use this class to instantiate validation
     schema for the data that will be validated.
     """
+
     def __init__(self, schema, error=None, ignore_extra_keys=False):
         self._schema = schema
         self._error = error
@@ -261,6 +277,10 @@ class Schema(object):
             coverage = set()  # matched schema keys
             # for each key and value find a schema entry matching them, if any
             sorted_skeys = sorted(s, key=self._dict_key_priority)
+            for skey in sorted_skeys:
+                if isinstance(skey, Or):
+                    skey.reset()
+
             for key, value in data.items():
                 for skey in sorted_skeys:
                     svalue = s[skey]
@@ -282,8 +302,8 @@ class Schema(object):
                             except SchemaError:
                                 continue
                             raise SchemaForbiddenKeyError(
-                                    'Forbidden key encountered: %r in %r' %
-                                    (nkey, data), e)
+                                'Forbidden key encountered: %r in %r' %
+                                (nkey, data), e)
                         else:
                             try:
                                 nvalue = Schema(svalue, error=e,

--- a/test_schema.py
+++ b/test_schema.py
@@ -78,6 +78,16 @@ def test_or():
     with SE: Or().validate(2)
 
 
+def test_or_only_one():
+    schema = Schema({
+        Or("test1", "test2", only_one=True): str
+    })
+    assert schema.validate({"test1": "value"})
+    assert schema.validate({"test2": "other_value"})
+    with SE: schema.validate({"test1": "value", "test2": "other_value"})
+    with SE: schema.validate({"othertest": "value"})
+
+
 def test_test():
     def unique_list(_list):
         return len(_list) == len(set(_list))


### PR DESCRIPTION
Fixes #106 

It's a bit sad that `Schema` has to know that `Or` has a `reset()` method but `Schema` has to know when to reset. Otherwise, subsequent `validate` calls of the same schema with the same value will fail. 
The other thing I considered is to subclass all the validators with a base class with an empty `reset()` method and always call it, `Or` would have overridden that method.

Let me know what you think!