### PR TITLE
Add Hook class. Allows to introduce custom handlers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -356,7 +356,7 @@ Here's an example where a `Deprecated` class is added to log warnings whenever a
 
     Schema({Deprecated("test", "custom error message."): object}, ignore_extra_keys=True).validate({"test": "value"})
     ...
-    >>> WARNING: `test` is deprecated. custom error message.
+    WARNING: `test` is deprecated. custom error message.
 
 Extra Keys
 ~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -233,7 +233,7 @@ You can specify keys as schemas too:
     None does not match 'not None here'
 
 This is useful if you want to check certain key-values, but don't care
-about other:
+about others:
 
 .. code:: python
 

--- a/schema.py
+++ b/schema.py
@@ -393,7 +393,8 @@ class Forbidden(Hook):
 
     @staticmethod
     def _default_function(nkey, data, error):
-        raise SchemaForbiddenKeyError('Forbidden key encountered: %r in %r' % (nkey, data), error)
+        raise SchemaForbiddenKeyError('Forbidden key encountered: %r in %r' %
+                                      (nkey, data), error)
 
 
 class Const(Schema):

--- a/schema.py
+++ b/schema.py
@@ -234,6 +234,11 @@ class Schema(object):
             return _priority(s._schema) + 0.5
         return _priority(s)
 
+    @staticmethod
+    def _is_optional_type(s):
+        """Return True if the given key is optional (does not have to be found"""
+        return any(isinstance(s, optional_type) for optional_type in [Optional, Hook])
+
     def is_valid(self, data):
         """Return whether the given data has passed all the validations
         that were specified in the given schema.
@@ -294,7 +299,7 @@ class Schema(object):
                                 new[nkey] = nvalue
                                 coverage.add(skey)
                                 break
-            required = set(k for k in s if type(k) not in [Optional, Forbidden, Hook])
+            required = set(k for k in s if not self._is_optional_type(k))
             if not required.issubset(coverage):
                 missing_keys = required - coverage
                 s_missing_keys = \

--- a/test_schema.py
+++ b/test_schema.py
@@ -7,7 +7,7 @@ import re
 import sys
 import copy
 import platform
-from unittest.mock import Mock
+from mock import Mock
 
 from pytest import raises, mark
 
@@ -260,10 +260,12 @@ def test_dict_hook():
     function_mock = Mock(return_value=None)
     hook = Hook('b', handler=function_mock)
 
-    assert Schema({hook: str, Optional('b'): object}).validate({'b': 'bye'}) == {'b': 'bye'}
+    assert Schema({hook: str,
+                   Optional('b'): object}).validate({'b': 'bye'}) == {'b': 'bye'}
     function_mock.assert_called_once()
 
-    assert Schema({hook: int, Optional('b'): object}).validate({'b': 'bye'}) == {'b': 'bye'}
+    assert Schema({hook: int,
+                   Optional('b'): object}).validate({'b': 'bye'}) == {'b': 'bye'}
     function_mock.assert_called_once()
 
     assert Schema({hook: str, 'b': object}).validate({'b': 'bye'}) == {'b': 'bye'}

--- a/test_schema.py
+++ b/test_schema.py
@@ -7,13 +7,14 @@ import re
 import sys
 import copy
 import platform
+from unittest.mock import Mock
 
 from pytest import raises, mark
 
 from schema import (Schema, Use, And, Or, Regex, Optional, Const,
                     SchemaError, SchemaWrongKeyError,
                     SchemaMissingKeyError, SchemaUnexpectedTypeError,
-                    SchemaForbiddenKeyError, Forbidden)
+                    SchemaForbiddenKeyError, Forbidden, Hook)
 
 if sys.version_info[0] == 3:
     basestring = str  # Python 3 does not have basestring
@@ -253,6 +254,20 @@ def test_dict_forbidden_keys():
             {'b': 'bye'})
     with raises(SchemaForbiddenKeyError):
         Schema({Forbidden('b'): object, Optional('b'): object}).validate({'b': 'bye'})
+
+
+def test_dict_hook():
+    function_mock = Mock(return_value=None)
+    hook = Hook('b', handler=function_mock)
+
+    assert Schema({hook: str, Optional('b'): object}).validate({'b': 'bye'}) == {'b': 'bye'}
+    function_mock.assert_called_once()
+
+    assert Schema({hook: int, Optional('b'): object}).validate({'b': 'bye'}) == {'b': 'bye'}
+    function_mock.assert_called_once()
+
+    assert Schema({hook: str, 'b': object}).validate({'b': 'bye'}) == {'b': 'bye'}
+    assert function_mock.call_count == 2
 
 
 def test_dict_optional_keys():

--- a/tox.ini
+++ b/tox.ini
@@ -9,11 +9,13 @@ envlist = py26, py27, py32, py33, py34, py35, py36, py37, pypy, coverage, pep8
 [testenv]
 commands = py.test
 deps = pytest
+       mock
 
 
 [testenv:py27]
 commands = py.test --doctest-glob=README.rst  # test documentation
 deps = pytest
+       mock
 
 [testenv:pep8]
 # pep8 disabled for E701 (multiple statements on one line) and E126 (continuation line over-indented for hanging indent)
@@ -28,6 +30,7 @@ commands = coverage erase
 deps = pytest
        pytest-cov
        coverage
+       mock
 
 [flake8]
 exclude=.venv,.git,.tox


### PR DESCRIPTION
* Add Hook class that allows custom handlers
* Make Forbidden a subclass of Hook that raises an exception as its handler
* My personal use case for this, creating a Deprecated hook that will be called that way: `Deprecated("attribute")`. My handler will simply be a function that logs a warning to the user when he uses that attribute. I am sure there are other use cases for a custom handler class.

Let me know what you think!