### PR TITLE
Don't accept boolens as instances of ints

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -319,7 +319,7 @@ class Schema(object):
 
             return new
         if flavor == TYPE:
-            if isinstance(data, s):
+            if isinstance(data, s) and not (isinstance(data, bool) and s == int):
                 return data
             else:
                 raise SchemaUnexpectedTypeError(

--- a/test_schema.py
+++ b/test_schema.py
@@ -40,6 +40,8 @@ def test_schema():
     with SE: Schema(int).validate('1')
     assert Schema(Use(int)).validate('1') == 1
     with SE: Schema(int).validate(int)
+    with SE: Schema(int).validate(True)
+    with SE: Schema(int).validate(False)
 
     assert Schema(str).validate('hai') == 'hai'
     with SE: Schema(str).validate(1)


### PR DESCRIPTION
Due to a historical artifact, when booleans were added to Python in 2.3,
they were implemented as a subclass of int (see PEP 285 for rationale).
As such isinstance(True, int) is True. Special case booleans to avoid
accepting this validation.