### PR TITLE
Fix Or reset() when Or is Optional

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -283,10 +283,12 @@ class Schema(object):
             # for each key and value find a schema entry matching them, if any
             sorted_skeys = sorted(s, key=self._dict_key_priority)
             for skey in sorted_skeys:
-                if getattr(skey, "reset", None):
+                if hasattr(skey, "reset"):
                     skey.reset()
 
-            for key, value in data.items():
+            # Evaluate dictionaries last
+            data_items = sorted(data.items(), key=lambda value: isinstance(value[1], dict))
+            for key, value in data_items:
                 for skey in sorted_skeys:
                     svalue = s[skey]
                     try:
@@ -404,7 +406,7 @@ class Optional(Schema):
                 self._schema == other._schema)
 
     def reset(self):
-        if getattr(self._schema, "reset", None):
+        if hasattr(self._schema, "reset"):
             self._schema.reset()
 
 

--- a/schema.py
+++ b/schema.py
@@ -287,7 +287,8 @@ class Schema(object):
                     skey.reset()
 
             # Evaluate dictionaries last
-            data_items = sorted(data.items(), key=lambda value: isinstance(value[1], dict))
+            data_items = sorted(data.items(),
+                                key=lambda value: isinstance(value[1], dict))
             for key, value in data_items:
                 for skey in sorted_skeys:
                     svalue = s[skey]

--- a/schema.py
+++ b/schema.py
@@ -283,7 +283,7 @@ class Schema(object):
             # for each key and value find a schema entry matching them, if any
             sorted_skeys = sorted(s, key=self._dict_key_priority)
             for skey in sorted_skeys:
-                if isinstance(skey, Or):
+                if getattr(skey, "reset", None):
                     skey.reset()
 
             for key, value in data.items():
@@ -402,6 +402,10 @@ class Optional(Schema):
                 getattr(self, 'default', self._MARKER) ==
                 getattr(other, 'default', self._MARKER) and
                 self._schema == other._schema)
+
+    def reset(self):
+        if getattr(self._schema, "reset", None):
+            self._schema.reset()
 
 
 class Hook(Schema):

--- a/test_schema.py
+++ b/test_schema.py
@@ -82,12 +82,18 @@ def test_or():
 
 
 def test_or_only_one():
+    or_rule = Or("test1", "test2", only_one=True)
     schema = Schema({
-        Or("test1", "test2", only_one=True): str
+        or_rule: str,
+        Optional("sub_schema"): {
+            Optional(or_rule): str
+        }
     })
     assert schema.validate({"test1": "value"})
+    assert schema.validate({"test1": "value", "sub_schema": {"test2": "value"}})
     assert schema.validate({"test2": "other_value"})
     with SE: schema.validate({"test1": "value", "test2": "other_value"})
+    with SE: schema.validate({"test1": "value", "sub_schema": {"test1": "value", "test2": "value"}})
     with SE: schema.validate({"othertest": "value"})
 
 

--- a/test_schema.py
+++ b/test_schema.py
@@ -93,7 +93,11 @@ def test_or_only_one():
     assert schema.validate({"test1": "value", "sub_schema": {"test2": "value"}})
     assert schema.validate({"test2": "other_value"})
     with SE: schema.validate({"test1": "value", "test2": "other_value"})
-    with SE: schema.validate({"test1": "value", "sub_schema": {"test1": "value", "test2": "value"}})
+    with SE:
+        schema.validate({
+            "test1": "value",
+            "sub_schema": {"test1": "value", "test2": "value"}
+        })
     with SE: schema.validate({"othertest": "value"})
 
 


### PR DESCRIPTION
This fixes an issue in https://github.com/keleshev/schema/pull/174. When Or was Optional, the reset method was not called