### PR TITLE
Travis CI python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,9 @@ matrix:
     - env: TOXENV=py37
       python: 3.7
       dist: xenial
+      sudo: true
     - env: TOXENV=coverage
-      python: 3.6
     - env: TOXENV=pep8
-      python: 3.6
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,23 @@ sudo: false
 
 language: python
 
-addons:
-  apt:
-    sources:
-      - deadsnakes
-    packages:
-      - python3.5
-      - python3.6
-      - python3.7
+matrix:
+  include:
+    - env: TOXENV=py27
+      python: 2.7
+    - env: TOXENV=py34
+      python: 3.4
+    - env: TOXENV=py35
+      python: 3.5
+    - env: TOXENV=py36
+      python: 3.6
+    - env: TOXENV=py37
+      python: 3.7
+      dist: xenial
+    - env: TOXENV=coverage
+      python: 3.6
+    - env: TOXENV=pep8
+      python: 3.6
 
 cache:
   pip: true
@@ -18,14 +27,6 @@ cache:
     - .tox
 
 install: pip install codecov tox
-
-env:
-  - TOX_ENV=py27
-  - TOX_ENV=py34
-  - TOX_ENV=py35
-  - TOX_ENV=py36
-  - TOX_ENV=coverage
-  - TOX_ENV=pep8
 
 script:
   - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ cache:
 install: pip install codecov tox
 
 script:
-  - tox -e $TOX_ENV
+  - tox
 
 # publish coverage only after a successful build
 after_success:

--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,11 @@ deps = pytest
        mock
 
 [testenv:pep8]
-# pep8 disabled for E701 (multiple statements on one line) and E126 (continuation line over-indented for hanging indent)
-commands = flake8 --max-line-length=90 --show-source -v --count --ignore=E701,E126
+# pep8 disabled for
+# - E701 (multiple statements on one line)
+# - E126 (continuation line over-indented for hanging indent)
+# - W504 (line break after binary operator)
+commands = flake8 --max-line-length=90 --show-source -v --count --ignore=E701,E126,W504
 deps = flake8
 
 [testenv:coverage]


### PR DESCRIPTION
Note:
- Travis CI requires `dist: xenial` + `sudo: true` for python 3.7 (https://github.com/travis-ci/travis-ci/issues/9815). These statements can be removed once they move to xenial by default
- For some reason my pep8 build is using pyflakes 2.0.0 which is performing W504 check by default, which would cause errors in `schema.py`. I suppressed that warning in tox.ini instead.