### PR TITLE
Generate JSON schema from schema

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -482,3 +482,49 @@ this is how you validate it using ``schema``:
 
 As you can see, **schema** validated data successfully, opened files and
 converted ``'3'`` to ``int``.
+
+(Beta feature) Generating JSON schema
+-------------------------------------------------------------------------------
+You can also generate standard `draft-07 JSON schema <https://json-schema.org/>`_ from a dict `Schema`.
+This can be used to add word completion and validation directly in code editors.
+Here's an example: 
+
+.. code:: python
+
+    >>> from schema import Optional, Schema
+    >>> import json
+    >>> s = Schema({"test": str,
+    ...             "nested": {Optional("other"): str}
+    ...             })
+    >>> json_schema = json.dumps(s.json_schema("https://example.com/my-schema.json"))
+
+    # json_schema
+    {
+        "type":"object",
+        "properties": {
+            "test": {"type": "string"},
+            "nested": {
+                "type":"object",
+                "properties": {
+                    "other": {"type": "string"}
+                },
+                "required": [],
+                "additionalProperties":false
+            }
+        },
+        "required":[
+            "test",
+            "nested"
+        ],
+        "additionalProperties":false,
+        "id":"https://example.com/my-schema.json",
+        "$schema":"http://json-schema.org/draft-07/schema#"
+    }
+
+Please note that this is a beta feature. Some JSON schema features are not implemented. Some caveats:
+
+- There are no object references, items of type `object` are always fully rendered
+- Some JSON schema types are not implemented. In those cases, an empty dict will be rendered.
+  This disables all validation for the item.
+- Validations other than type are not implemented. This includes features such as integers'
+  minimum and maximum or arrays' minItems

--- a/schema.py
+++ b/schema.py
@@ -380,10 +380,18 @@ class Schema(object):
                               e.format(data) if e else None)
 
     def json_schema(self, schema_id=None, is_main_schema=True):
+        """Generate a draft-07 JSON schema dict representing the Schema.
+        This method can only be called when the Schema's value is a dict.
+        This method must be called with a schema_id. Calling it without one
+        is used in a recursive context for sub schemas."""
         Schema = self.__class__
         s = self._schema
         i = self._ignore_extra_keys
         flavor = _priority(s)
+
+        if flavor != DICT and is_main_schema:
+            raise ValueError("The main schema must be a dict.")
+
         if flavor == TYPE:
             # Handle type
             return {"type": {

--- a/test_schema.py
+++ b/test_schema.py
@@ -650,7 +650,10 @@ def test_json_schema():
 
 
 def test_json_schema_types():
-    s = Schema({"test_str": str, "test_int": int, "test_float": float, "test_bool": bool})
+    s = Schema({Optional("test_str"): str,
+                Optional("test_int"): int,
+                Optional("test_float"): float,
+                Optional("test_bool"): bool})
     assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "id": "my-id",
@@ -660,7 +663,7 @@ def test_json_schema_types():
             "test_float": {"type": "number"},
             "test_bool": {"type": "boolean"}
         },
-        "required": ['test_str', 'test_int', 'test_float', 'test_bool'],
+        "required": [],
         "additionalProperties": False,
         "type": "object"
     }
@@ -771,20 +774,20 @@ def test_json_schema_and_types():
 
 def test_json_schema_object_or_array_of_object():
     # Complex test where "test" accepts either an object or an array of that object
-    o = {"param1": "test1", "param2": "test2"}
+    o = {"param1": "test1", Optional("param2"): "test2"}
     s = Schema({"test": Or(o, [o])})
     assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "id": "my-id",
         "properties": {"test": {"anyOf": [{'additionalProperties': False,
                                            'properties': {'param1': {}, 'param2': {}},
-                                           'required': ['param1', 'param2'],
+                                           'required': ['param1'],
                                            'type': 'object'
                                            }, {"type": "array",
                                                "items": {'additionalProperties': False,
                                                          'properties': {'param1': {},
                                                                         'param2': {}},
-                                                         'required': ['param1', 'param2'],
+                                                         'required': ['param1'],
                                                          'type': 'object'}
                                                }
                                           ]

--- a/test_schema.py
+++ b/test_schema.py
@@ -815,3 +815,9 @@ def test_json_schema_no_id():
     s = Schema({"test": int})
     with raises(ValueError):
         s.json_schema()
+
+
+def test_json_schema_not_a_dict():
+    s = Schema(int)
+    with raises(ValueError):
+        s.json_schema()

--- a/test_schema.py
+++ b/test_schema.py
@@ -797,3 +797,21 @@ def test_json_schema_object_or_array_of_object():
         "additionalProperties": False,
         "type": "object"
     }
+
+
+def test_json_schema_forbidden_key_ignored():
+    s = Schema({Forbidden("forbidden"): str, "test": str})
+    assert s.json_schema("my-id") == {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "id": "my-id",
+        "properties": {"test": {"type": "string"}},
+        "required": ["test"],
+        "additionalProperties": False,
+        "type": "object"
+    }
+
+
+def test_json_schema_no_id():
+    s = Schema({"test": int})
+    with raises(ValueError):
+        s.json_schema()

--- a/test_schema.py
+++ b/test_schema.py
@@ -782,7 +782,8 @@ def test_json_schema_object_or_array_of_object():
                                            'type': 'object'
                                            }, {"type": "array",
                                                "items": {'additionalProperties': False,
-                                                         'properties': {'param1': {}, 'param2': {}},
+                                                         'properties': {'param1': {},
+                                                                        'param2': {}},
                                                          'required': ['param1', 'param2'],
                                                          'type': 'object'}
                                                }


### PR DESCRIPTION
Big-ish PR but the title is self explanatory. Implementation of draft-7 json schema generation: https://json-schema.org/.
Some caveats:
- Some types are not handled. In that case, the `{}` dict is returned (no checks in that case)
- There are no object references, objects are always fully rendered
- Also there may be other features of JSON Schema that I did not implement (because I'm not aware of them :smile: )
- I tested it with a very large schema, and all of it works. I'd love to see some use cases that I did not think of though
- I did not do any documentation, if we do any, it should probably be noted that this is a beta feature. And I wanted to have your opinion on this feature before writing any of it.

Let me know what you think!