### PR TITLE
When ignoring extra keys,  Or's only_one should still be handled

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -302,13 +302,18 @@ In a dictionary, you can also combine two keys in a "one or the other" manner. T
 so, use the `Or` class as a key:
 
 .. code:: python
-    from schema import Or, Schema
-    schema = Schema({
-        Or("key1", "key2", only_one=True): str
-    })
+    >>> from schema import Or, Schema
+    >>> schema = Schema({
+    ...    Or("key1", "key2", only_one=True): str
+    ... })
 
-    schema.validate({"key1": "test"}) # Ok
-    schema.validate({"key1": "test", "key2": "test"}) # SchemaWrongKeyError
+    >>> schema.validate({"key1": "test"}) # Ok
+    {'key1': 'test'}
+
+    >>> schema.validate({"key1": "test", "key2": "test"}) # SchemaError
+    Traceback (most recent call last):
+    ...
+    SchemaError: There are multiple keys present from the Or('key1', 'key2') condition
 
 Hooks
 ~~~~~~~~~~

--- a/test_schema.py
+++ b/test_schema.py
@@ -100,6 +100,11 @@ def test_or_only_one():
         })
     with SE: schema.validate({"othertest": "value"})
 
+    extra_keys_schema = Schema({or_rule: str}, ignore_extra_keys=True)
+    assert extra_keys_schema.validate({"test1": "value", "other-key": "value"})
+    assert extra_keys_schema.validate({"test2": "other_value"})
+    with SE: extra_keys_schema.validate({"test1": "value", "test2": "other_value"})
+
 
 def test_test():
     def unique_list(_list):


### PR DESCRIPTION
Sorry for another PR about this. I noticed that Or's `only_one` condition didn't work when mixed with `ìgnore_extra_keys` as it was relying on the `WrongKey` exception. I instead implemented a type of Error that stops the execution immediately.

Let me know if you see anything I might have missed. 
Thanks