### PR TITLE
Use correct singular/plural form of “key(s)” in error messages

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -344,14 +344,17 @@ class Schema(object):
                 s_missing_keys = \
                     ', '.join(repr(k) for k in sorted(missing_keys, key=repr))
                 raise \
-                    SchemaMissingKeyError('Missing keys: ' + s_missing_keys, e)
+                    SchemaMissingKeyError(
+                        'Missing key%s: %s' % (_plural_s(missing_keys), s_missing_keys),
+                        e)
             if not self._ignore_extra_keys and (len(new) != len(data)):
                 wrong_keys = set(data.keys()) - set(new.keys())
                 s_wrong_keys = \
                     ', '.join(repr(k) for k in sorted(wrong_keys, key=repr))
                 raise \
                     SchemaWrongKeyError(
-                        'Wrong keys %s in %r' % (s_wrong_keys, data),
+                        'Wrong key%s %s in %r' % (
+                            _plural_s(wrong_keys), s_wrong_keys, data),
                         e.format(data) if e else None)
 
             # Apply default-having optionals that haven't been used:
@@ -534,3 +537,7 @@ def _callable_str(callable_):
     if hasattr(callable_, '__name__'):
         return callable_.__name__
     return str(callable_)
+
+
+def _plural_s(sized):
+    return "s" if len(sized) > 1 else ""

--- a/test_schema.py
+++ b/test_schema.py
@@ -206,26 +206,32 @@ def test_dict():
         try:
             Schema({'key': 5}).validate({})
         except SchemaMissingKeyError as e:
-            assert e.args[0] == "Missing keys: 'key'"
+            assert e.args[0] == "Missing key: 'key'"
             raise
     with SE:
         try:
             Schema({'key': 5}).validate({'n': 5})
         except SchemaMissingKeyError as e:
-            assert e.args[0] == "Missing keys: 'key'"
+            assert e.args[0] == "Missing key: 'key'"
+            raise
+    with SE:
+        try:
+            Schema({'key': 5, 'key2': 5}).validate({'n': 5})
+        except SchemaMissingKeyError as e:
+            assert e.args[0] == "Missing keys: 'key', 'key2'"
             raise
     with SE:
         try:
             Schema({}).validate({'n': 5})
         except SchemaWrongKeyError as e:
-            assert e.args[0] == "Wrong keys 'n' in {'n': 5}"
+            assert e.args[0] == "Wrong key 'n' in {'n': 5}"
             raise
     with SE:
         try:
             Schema({'key': 5}).validate({'key': 5, 'bad': 5})
         except SchemaWrongKeyError as e:
-            assert e.args[0] in ["Wrong keys 'bad' in {'key': 5, 'bad': 5}",
-                                 "Wrong keys 'bad' in {'bad': 5, 'key': 5}"]
+            assert e.args[0] in ["Wrong key 'bad' in {'key': 5, 'bad': 5}",
+                                 "Wrong key 'bad' in {'bad': 5, 'key': 5}"]
             raise
     with SE:
         try:
@@ -548,7 +554,7 @@ def test_missing_keys_exception_with_non_str_dict_keys():
         try:
             Schema({1: 'x'}).validate(dict())
         except SchemaMissingKeyError as e:
-            assert e.args[0] == "Missing keys: 1"
+            assert e.args[0] == "Missing key: 1"
             raise
 
 


### PR DESCRIPTION
Also added a new test case for covering the plural case of SchemaMissingKeyError.