### PR TITLE
allow Optional(..., default=obj) to be a callable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -268,6 +268,14 @@ data matches:
 Defaults are used verbatim, not passed through any validators specified in the
 value.
 
+default can also be a callable:
+
+.. code:: python
+
+    >>> from schema import Schema, Optional
+    >>> Schema({Optional('data', default=dict): {}}).validate({}) == {'data': {}}
+    True
+
 Also, a caveat: If you specify types, **schema** won't validate the empty dict:
 
 .. code:: python

--- a/schema.py
+++ b/schema.py
@@ -361,7 +361,8 @@ class Schema(object):
             defaults = set(k for k in s if type(k) is Optional and
                            hasattr(k, 'default')) - coverage
             for default in defaults:
-                new[default.key] = default.default() if callable(default.default) else default.default
+                new[default.key] = default.default() if callable(default.default) \
+                                                     else default.default
 
             return new
         if flavor == TYPE:

--- a/schema.py
+++ b/schema.py
@@ -361,7 +361,7 @@ class Schema(object):
             defaults = set(k for k in s if type(k) is Optional and
                            hasattr(k, 'default')) - coverage
             for default in defaults:
-                new[default.key] = default.default
+                new[default.key] = default.default() if callable(default.default) else default.default
 
             return new
         if flavor == TYPE:


### PR DESCRIPTION
allow optional to take a callable as default  (dict or list for example)