### PR TITLE
Set long_description_content_type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     url="https://github.com/keleshev/schema",
     py_modules=["schema"],
     long_description=codecs.open("README.rst", "r", "utf-8").read(),
+    long_description_content_type='text/x-rst',
     install_requires=open("requirements.txt", "r").read().split("\n"),
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
This is so things like [pypi.org](https://pypi.org/project/schema/) don't have to guess how to render the package description.