### PR TITLE
 Add Literal type to add description to JSON schemas

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -32,8 +32,12 @@ class SchemaError(Exception):
     """Error during Schema validation."""
 
     def __init__(self, autos, errors=None):
-        self.autos = autos if type(autos) is list else [autos]
-        self.errors = errors if type(errors) is list else [errors]
+        self.autos = (
+            autos if type(autos) is list else [autos]
+        )
+        self.errors = (
+            errors if type(errors) is list else [errors]
+        )
         Exception.__init__(self, self.code)
 
     @property
@@ -50,10 +54,18 @@ class SchemaError(Exception):
             seen = set()
             seen_add = seen.add
             # This way removes duplicates while preserving the order.
-            return [x for x in seq if x not in seen and not seen_add(x)]
+            return [
+                x
+                for x in seq
+                if x not in seen and not seen_add(x)
+            ]
 
-        data_set = uniq(i for i in self.autos if i is not None)
-        error_list = uniq(i for i in self.errors if i is not None)
+        data_set = uniq(
+            i for i in self.autos if i is not None
+        )
+        error_list = uniq(
+            i for i in self.errors if i is not None
+        )
         if error_list:
             return "\n".join(error_list)
         return "\n".join(data_set)
@@ -100,16 +112,29 @@ class And(object):
 
     def __init__(self, *args, **kw):
         self._args = args
-        if not set(kw).issubset({"error", "schema", "ignore_extra_keys"}):
-            diff = {"error", "schema", "ignore_extra_keys"}.difference(kw)
-            raise TypeError("Unknown keyword arguments %r" % list(diff))
+        if not set(kw).issubset(
+            {"error", "schema", "ignore_extra_keys"}
+        ):
+            diff = {
+                "error",
+                "schema",
+                "ignore_extra_keys",
+            }.difference(kw)
+            raise TypeError(
+                "Unknown keyword arguments %r" % list(diff)
+            )
         self._error = kw.get("error")
-        self._ignore_extra_keys = kw.get("ignore_extra_keys", False)
+        self._ignore_extra_keys = kw.get(
+            "ignore_extra_keys", False
+        )
         # You can pass your inherited Schema class.
         self._schema = kw.get("schema", Schema)
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, ", ".join(repr(a) for a in self._args))
+        return "%s(%s)" % (
+            self.__class__.__name__,
+            ", ".join(repr(a) for a in self._args),
+        )
 
     @property
     def args(self):
@@ -123,7 +148,14 @@ class And(object):
         :param data: to be validated with sub defined schemas.
         :return: returns validated data
         """
-        for s in [self._schema(s, error=self._error, ignore_extra_keys=self._ignore_extra_keys) for s in self._args]:
+        for s in [
+            self._schema(
+                s,
+                error=self._error,
+                ignore_extra_keys=self._ignore_extra_keys,
+            )
+            for s in self._args
+        ]:
             data = s.validate(data)
         return data
 
@@ -141,7 +173,12 @@ class Or(And):
         failed = self.match_count > 1 and self.only_one
         self.match_count = 0
         if failed:
-            raise SchemaOnlyOneAllowedError(["There are multiple keys present " + "from the %r condition" % self])
+            raise SchemaOnlyOneAllowedError(
+                [
+                    "There are multiple keys present "
+                    + "from the %r condition" % self
+                ]
+            )
 
     def validate(self, data):
         """
@@ -151,7 +188,14 @@ class Or(And):
         :return: return validated data if not validation
         """
         autos, errors = [], []
-        for s in [self._schema(s, error=self._error, ignore_extra_keys=self._ignore_extra_keys) for s in self._args]:
+        for s in [
+            self._schema(
+                s,
+                error=self._error,
+                ignore_extra_keys=self._ignore_extra_keys,
+            )
+            for s in self._args
+        ]:
             try:
                 validation = s.validate(data)
                 self.match_count += 1
@@ -161,8 +205,14 @@ class Or(And):
             except SchemaError as _x:
                 autos, errors = _x.autos, _x.errors
         raise SchemaError(
-            ["%r did not validate %r" % (self, data)] + autos,
-            [self._error.format(data) if self._error else None] + errors,
+            ["%r did not validate %r" % (self, data)]
+            + autos,
+            [
+                self._error.format(data)
+                if self._error
+                else None
+            ]
+            + errors,
         )
 
 
@@ -186,10 +236,16 @@ class Regex(object):
 
     def __init__(self, pattern_str, flags=0, error=None):
         self._pattern_str = pattern_str
-        flags_list = [Regex.NAMES[i] for i, f in enumerate("{0:09b}".format(flags)) if f != "0"]  # Name for each bit
+        flags_list = [
+            Regex.NAMES[i]
+            for i, f in enumerate("{0:09b}".format(flags))
+            if f != "0"
+        ]  # Name for each bit
 
         if flags_list:
-            self._flags_names = ", flags=" + "|".join(flags_list)
+            self._flags_names = ", flags=" + "|".join(
+                flags_list
+            )
         else:
             self._flags_names = ""
 
@@ -197,7 +253,11 @@ class Regex(object):
         self._error = error
 
     def __repr__(self):
-        return "%s(%r%s)" % (self.__class__.__name__, self._pattern_str, self._flags_names)
+        return "%s(%r%s)" % (
+            self.__class__.__name__,
+            self._pattern_str,
+            self._flags_names,
+        )
 
     @property
     def pattern_str(self):
@@ -216,9 +276,13 @@ class Regex(object):
             if self._pattern.search(data):
                 return data
             else:
-                raise SchemaError("%r does not match %r" % (self, data), e)
+                raise SchemaError(
+                    "%r does not match %r" % (self, data), e
+                )
         except TypeError:
-            raise SchemaError("%r is not string nor buffer" % data, e)
+            raise SchemaError(
+                "%r is not string nor buffer" % data, e
+            )
 
 
 class Use(object):
@@ -229,24 +293,44 @@ class Use(object):
 
     def __init__(self, callable_, error=None):
         if not callable(callable_):
-            raise TypeError("Expected a callable, not %r" % callable_)
+            raise TypeError(
+                "Expected a callable, not %r" % callable_
+            )
         self._callable = callable_
         self._error = error
 
     def __repr__(self):
-        return "%s(%r)" % (self.__class__.__name__, self._callable)
+        return "%s(%r)" % (
+            self.__class__.__name__,
+            self._callable,
+        )
 
     def validate(self, data):
         try:
             return self._callable(data)
         except SchemaError as x:
-            raise SchemaError([None] + x.autos, [self._error.format(data) if self._error else None] + x.errors)
+            raise SchemaError(
+                [None] + x.autos,
+                [
+                    self._error.format(data)
+                    if self._error
+                    else None
+                ]
+                + x.errors,
+            )
         except BaseException as x:
             f = _callable_str(self._callable)
-            raise SchemaError("%s(%r) raised %r" % (f, data, x), self._error.format(data) if self._error else None)
+            raise SchemaError(
+                "%s(%r) raised %r" % (f, data, x),
+                self._error.format(data)
+                if self._error
+                else None,
+            )
 
 
-COMPARABLE, CALLABLE, VALIDATOR, TYPE, DICT, ITERABLE = range(6)
+COMPARABLE, CALLABLE, VALIDATOR, TYPE, DICT, ITERABLE = range(
+    6
+)
 
 
 def _priority(s):
@@ -273,7 +357,14 @@ class Schema(object):
     schema for the data that will be validated.
     """
 
-    def __init__(self, schema, error=None, ignore_extra_keys=False, name=None, description=None):
+    def __init__(
+        self,
+        schema,
+        error=None,
+        ignore_extra_keys=False,
+        name=None,
+        description=None,
+    ):
         self._schema = schema
         self._error = error
         self._ignore_extra_keys = ignore_extra_keys
@@ -281,7 +372,10 @@ class Schema(object):
         self._description = description
 
     def __repr__(self):
-        return "%s(%r)" % (self.__class__.__name__, self._schema)
+        return "%s(%r)" % (
+            self.__class__.__name__,
+            self._schema,
+        )
 
     @property
     def schema(self):
@@ -303,7 +397,10 @@ class Schema(object):
     @staticmethod
     def _is_optional_type(s):
         """Return True if the given key is optional (does not have to be found)"""
-        return any(isinstance(s, optional_type) for optional_type in [Optional, Hook])
+        return any(
+            isinstance(s, optional_type)
+            for optional_type in [Optional, Hook]
+        )
 
     def is_valid(self, data):
         """Return whether the given data has passed all the validations
@@ -322,7 +419,9 @@ class Schema(object):
         message that gets raised when a schema error occurs.
         """
         if self._name:
-            message = "{0!r} {1!s}".format(self._name, message)
+            message = "{0!r} {1!s}".format(
+                self._name, message
+            )
         return message
 
     def validate(self, data):
@@ -333,27 +432,43 @@ class Schema(object):
         flavor = _priority(s)
         if flavor == ITERABLE:
             data = Schema(type(s), error=e).validate(data)
-            o = Or(*s, error=e, schema=Schema, ignore_extra_keys=i)
+            o = Or(
+                *s,
+                error=e,
+                schema=Schema,
+                ignore_extra_keys=i
+            )
             return type(data)(o.validate(d) for d in data)
         if flavor == DICT:
             exitstack = ExitStack()
             data = Schema(dict, error=e).validate(data)
-            new = type(data)()  # new - is a dict of the validated values
+            new = type(
+                data
+            )()  # new - is a dict of the validated values
             coverage = set()  # matched schema keys
             # for each key and value find a schema entry matching them, if any
-            sorted_skeys = sorted(s, key=self._dict_key_priority)
+            sorted_skeys = sorted(
+                s, key=self._dict_key_priority
+            )
             for skey in sorted_skeys:
                 if hasattr(skey, "reset"):
                     exitstack.callback(skey.reset)
 
             with exitstack:
                 # Evaluate dictionaries last
-                data_items = sorted(data.items(), key=lambda value: isinstance(value[1], dict))
+                data_items = sorted(
+                    data.items(),
+                    key=lambda value: isinstance(
+                        value[1], dict
+                    ),
+                )
                 for key, value in data_items:
                     for skey in sorted_skeys:
                         svalue = s[skey]
                         try:
-                            nkey = Schema(skey, error=e).validate(key)
+                            nkey = Schema(
+                                skey, error=e
+                            ).validate(key)
                         except SchemaError:
                             pass
                         else:
@@ -367,69 +482,146 @@ class Schema(object):
                                 # value has a certain type, and allowing Forbidden to
                                 # work well in combination with Optional.
                                 try:
-                                    nvalue = Schema(svalue, error=e).validate(value)
+                                    nvalue = Schema(
+                                        svalue, error=e
+                                    ).validate(value)
                                 except SchemaError:
                                     continue
                                 skey.handler(nkey, data, e)
                             else:
                                 try:
-                                    nvalue = Schema(svalue, error=e, ignore_extra_keys=i).validate(value)
+                                    nvalue = Schema(
+                                        svalue,
+                                        error=e,
+                                        ignore_extra_keys=i,
+                                    ).validate(value)
                                 except SchemaError as x:
-                                    k = "Key '%s' error:" % nkey
-                                    message = self._prepend_schema_name(k)
-                                    raise SchemaError([message] + x.autos, [e] + x.errors)
+                                    k = (
+                                        "Key '%s' error:"
+                                        % nkey
+                                    )
+                                    message = self._prepend_schema_name(
+                                        k
+                                    )
+                                    raise SchemaError(
+                                        [message] + x.autos,
+                                        [e] + x.errors,
+                                    )
                                 else:
                                     new[nkey] = nvalue
                                     coverage.add(skey)
                                     break
-            required = set(k for k in s if not self._is_optional_type(k))
+            required = set(
+                k
+                for k in s
+                if not self._is_optional_type(k)
+            )
             if not required.issubset(coverage):
                 missing_keys = required - coverage
-                s_missing_keys = ", ".join(repr(k) for k in sorted(missing_keys, key=repr))
-                message = "Missing key%s: %s" % (_plural_s(missing_keys), s_missing_keys)
+                s_missing_keys = ", ".join(
+                    repr(k)
+                    for k in sorted(missing_keys, key=repr)
+                )
+                message = "Missing key%s: %s" % (
+                    _plural_s(missing_keys),
+                    s_missing_keys,
+                )
                 message = self._prepend_schema_name(message)
                 raise SchemaMissingKeyError(message, e)
-            if not self._ignore_extra_keys and (len(new) != len(data)):
-                wrong_keys = set(data.keys()) - set(new.keys())
-                s_wrong_keys = ", ".join(repr(k) for k in sorted(wrong_keys, key=repr))
-                message = "Wrong key%s %s in %r" % (_plural_s(wrong_keys), s_wrong_keys, data)
+            if not self._ignore_extra_keys and (
+                len(new) != len(data)
+            ):
+                wrong_keys = set(data.keys()) - set(
+                    new.keys()
+                )
+                s_wrong_keys = ", ".join(
+                    repr(k)
+                    for k in sorted(wrong_keys, key=repr)
+                )
+                message = "Wrong key%s %s in %r" % (
+                    _plural_s(wrong_keys),
+                    s_wrong_keys,
+                    data,
+                )
                 message = self._prepend_schema_name(message)
-                raise SchemaWrongKeyError(message, e.format(data) if e else None)
+                raise SchemaWrongKeyError(
+                    message, e.format(data) if e else None
+                )
 
             # Apply default-having optionals that haven't been used:
-            defaults = set(k for k in s if type(k) is Optional and hasattr(k, "default")) - coverage
+            defaults = (
+                set(
+                    k
+                    for k in s
+                    if type(k) is Optional
+                    and hasattr(k, "default")
+                )
+                - coverage
+            )
             for default in defaults:
-                new[default.key] = default.default() if callable(default.default) else default.default
+                new[default.key] = (
+                    default.default()
+                    if callable(default.default)
+                    else default.default
+                )
 
             return new
         if flavor == TYPE:
-            if isinstance(data, s) and not (isinstance(data, bool) and s == int):
+            if isinstance(data, s) and not (
+                isinstance(data, bool) and s == int
+            ):
                 return data
             else:
-                message = "%r should be instance of %r" % (data, s.__name__)
+                message = "%r should be instance of %r" % (
+                    data,
+                    s.__name__,
+                )
                 message = self._prepend_schema_name(message)
-                raise SchemaUnexpectedTypeError(message, e.format(data) if e else None)
+                raise SchemaUnexpectedTypeError(
+                    message, e.format(data) if e else None
+                )
         if flavor == VALIDATOR:
             try:
                 return s.validate(data)
             except SchemaError as x:
-                raise SchemaError([None] + x.autos, [e] + x.errors)
+                raise SchemaError(
+                    [None] + x.autos, [e] + x.errors
+                )
             except BaseException as x:
-                message = "%r.validate(%r) raised %r" % (s, data, x)
+                message = "%r.validate(%r) raised %r" % (
+                    s,
+                    data,
+                    x,
+                )
                 message = self._prepend_schema_name(message)
-                raise SchemaError(message, self._error.format(data) if self._error else None)
+                raise SchemaError(
+                    message,
+                    self._error.format(data)
+                    if self._error
+                    else None,
+                )
         if flavor == CALLABLE:
             f = _callable_str(s)
             try:
                 if s(data):
                     return data
             except SchemaError as x:
-                raise SchemaError([None] + x.autos, [e] + x.errors)
+                raise SchemaError(
+                    [None] + x.autos, [e] + x.errors
+                )
             except BaseException as x:
                 message = "%s(%r) raised %r" % (f, data, x)
                 message = self._prepend_schema_name(message)
-                raise SchemaError(message, self._error.format(data) if self._error else None)
-            message = "%s(%r) should evaluate to True" % (f, data)
+                raise SchemaError(
+                    message,
+                    self._error.format(data)
+                    if self._error
+                    else None,
+                )
+            message = "%s(%r) should evaluate to True" % (
+                f,
+                data,
+            )
             message = self._prepend_schema_name(message)
             raise SchemaError(message, e)
         if s == data:
@@ -440,9 +632,16 @@ class Schema(object):
         else:
             message = "%r does not match %r" % (s, data)
             message = self._prepend_schema_name(message)
-            raise SchemaError(message, e.format(data) if e else None)
+            raise SchemaError(
+                message, e.format(data) if e else None
+            )
 
-    def json_schema(self, schema_id=None, is_main_schema=True, description=None):
+    def json_schema(
+        self,
+        schema_id=None,
+        is_main_schema=True,
+        description=None,
+    ):
         """Generate a draft-07 JSON schema dict representing the Schema.
         This method can only be called when the Schema's value is a dict.
         This method must be called with a schema_id. Calling it without one
@@ -472,7 +671,9 @@ class Schema(object):
             return_schema["description"] = description
 
         if flavor != DICT and is_main_schema:
-            raise ValueError("The main schema must be a dict.")
+            raise ValueError(
+                "The main schema must be a dict."
+            )
 
         if flavor == TYPE:
             # Handle type
@@ -483,16 +684,25 @@ class Schema(object):
 
             return_schema["type"] = "array"
             if len(s) == 1:
-                return_schema["items"] = Schema(s[0]).json_schema(is_main_schema=False)
+                return_schema["items"] = Schema(
+                    s[0]
+                ).json_schema(is_main_schema=False)
             elif len(s) > 1:
-                return_schema["items"] = Schema(Or(*s)).json_schema(is_main_schema=False)
+                return_schema["items"] = Schema(
+                    Or(*s)
+                ).json_schema(is_main_schema=False)
             return return_schema
 
         elif isinstance(s, Or):
             # Handle Or values
 
             # Check if we can use an enum
-            if all(priority == COMPARABLE for priority in [_priority(value) for value in s.args]):
+            if all(
+                priority == COMPARABLE
+                for priority in [
+                    _priority(value) for value in s.args
+                ]
+            ):
                 # All values are simple, can use enum or const
                 if len(s.args) == 1:
                     return_schema["const"] = s.args[0]
@@ -503,7 +713,9 @@ class Schema(object):
             # No enum, let's go with recursive calls
             any_of_values = []
             for or_key in s.args:
-                new_value = Schema(or_key).json_schema(is_main_schema=False)
+                new_value = Schema(or_key).json_schema(
+                    is_main_schema=False
+                )
                 if new_value not in any_of_values:
                     any_of_values.append(new_value)
             return_schema["anyOf"] = any_of_values
@@ -512,8 +724,13 @@ class Schema(object):
             # Handle And values
             all_of_values = []
             for and_key in s.args:
-                new_value = Schema(and_key).json_schema(is_main_schema=False)
-                if new_value != {} and new_value not in all_of_values:
+                new_value = Schema(and_key).json_schema(
+                    is_main_schema=False
+                )
+                if (
+                    new_value != {}
+                    and new_value not in all_of_values
+                ):
                     all_of_values.append(new_value)
             return_schema["allOf"] = all_of_values
             return return_schema
@@ -561,29 +778,50 @@ class Schema(object):
 
             sub_schema = s[key]
             if not isinstance(sub_schema, Schema):
-                sub_schema = Schema(s[key], ignore_extra_keys=i)
+                sub_schema = Schema(
+                    s[key], ignore_extra_keys=i
+                )
 
             key_name = _get_key_name(key)
 
             if isinstance(key_name, str):
                 if not isinstance(key, Optional):
                     required_keys.append(key_name)
-                expanded_schema[key_name] = sub_schema.json_schema(is_main_schema=False, description=_get_key_description(key))
+                expanded_schema[
+                    key_name
+                ] = sub_schema.json_schema(
+                    is_main_schema=False,
+                    description=_get_key_description(key),
+                )
             elif isinstance(key_name, Or):
                 # JSON schema does not support having a key named one name or another, so we just add both options
                 # This is less strict because we cannot enforce that one or the other is required
 
                 for or_key in key_name.args:
-                    expanded_schema[_get_key_name(or_key)] = sub_schema.json_schema(is_main_schema=False, description=_get_key_description(or_key))
+                    expanded_schema[
+                        _get_key_name(or_key)
+                    ] = sub_schema.json_schema(
+                        is_main_schema=False,
+                        description=_get_key_description(
+                            or_key
+                        ),
+                    )
 
-        return_schema.update({
-            "type": "object",
-            "properties": expanded_schema,
-            "required": required_keys,
-            "additionalProperties": i,
-        })
+        return_schema.update(
+            {
+                "type": "object",
+                "properties": expanded_schema,
+                "required": required_keys,
+                "additionalProperties": i,
+            }
+        )
         if is_main_schema:
-            return_schema.update({"id": schema_id, "$schema": "http://json-schema.org/draft-07/schema#"})
+            return_schema.update(
+                {
+                    "id": schema_id,
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                }
+            )
             if self._name:
                 return_schema["title"] = self._name
         if self._description:
@@ -617,7 +855,8 @@ class Optional(Schema):
     def __eq__(self, other):
         return (
             self.__class__ is other.__class__
-            and getattr(self, "default", self._MARKER) == getattr(other, "default", self._MARKER)
+            and getattr(self, "default", self._MARKER)
+            == getattr(other, "default", self._MARKER)
             and self._schema == other._schema
         )
 
@@ -628,7 +867,9 @@ class Optional(Schema):
 
 class Hook(Schema):
     def __init__(self, *args, **kwargs):
-        self.handler = kwargs.pop("handler", lambda *args: None)
+        self.handler = kwargs.pop(
+            "handler", lambda *args: None
+        )
         super(Hook, self).__init__(*args, **kwargs)
         self.key = self._schema
 
@@ -640,7 +881,11 @@ class Forbidden(Hook):
 
     @staticmethod
     def _default_function(nkey, data, error):
-        raise SchemaForbiddenKeyError("Forbidden key encountered: %r in %r" % (nkey, data), error)
+        raise SchemaForbiddenKeyError(
+            "Forbidden key encountered: %r in %r"
+            % (nkey, data),
+            error,
+        )
 
 
 class Literal(object):

--- a/test_schema.py
+++ b/test_schema.py
@@ -78,13 +78,21 @@ def test_schema():
 
 
 def test_validate_file():
-    assert Schema(Use(open)).validate("LICENSE-MIT").read().startswith("Copyright")
+    assert (
+        Schema(Use(open))
+        .validate("LICENSE-MIT")
+        .read()
+        .startswith("Copyright")
+    )
     with SE:
         Schema(Use(open)).validate("NON-EXISTENT")
     assert Schema(os.path.exists).validate(".") == "."
     with SE:
         Schema(os.path.exists).validate("./non-existent/")
-    assert Schema(os.path.isfile).validate("LICENSE-MIT") == "LICENSE-MIT"
+    assert (
+        Schema(os.path.isfile).validate("LICENSE-MIT")
+        == "LICENSE-MIT"
+    )
     with SE:
         Schema(os.path.isfile).validate("NON-EXISTENT")
 
@@ -93,7 +101,10 @@ def test_and():
     assert And(int, lambda n: 0 < n < 5).validate(3) == 3
     with SE:
         And(int, lambda n: 0 < n < 5).validate(3.33)
-    assert And(Use(int), lambda n: 0 < n < 5).validate(3.33) == 3
+    assert (
+        And(Use(int), lambda n: 0 < n < 5).validate(3.33)
+        == 3
+    )
     with SE:
         And(Use(int), lambda n: 0 < n < 5).validate("3.33")
 
@@ -110,22 +121,49 @@ def test_or():
 
 def test_or_only_one():
     or_rule = Or("test1", "test2", only_one=True)
-    schema = Schema({or_rule: str, Optional("sub_schema"): {Optional(copy.deepcopy(or_rule)): str}})
+    schema = Schema(
+        {
+            or_rule: str,
+            Optional("sub_schema"): {
+                Optional(copy.deepcopy(or_rule)): str
+            },
+        }
+    )
     assert schema.validate({"test1": "value"})
-    assert schema.validate({"test1": "value", "sub_schema": {"test2": "value"}})
+    assert schema.validate(
+        {"test1": "value", "sub_schema": {"test2": "value"}}
+    )
     assert schema.validate({"test2": "other_value"})
     with SE:
-        schema.validate({"test1": "value", "test2": "other_value"})
+        schema.validate(
+            {"test1": "value", "test2": "other_value"}
+        )
     with SE:
-        schema.validate({"test1": "value", "sub_schema": {"test1": "value", "test2": "value"}})
+        schema.validate(
+            {
+                "test1": "value",
+                "sub_schema": {
+                    "test1": "value",
+                    "test2": "value",
+                },
+            }
+        )
     with SE:
         schema.validate({"othertest": "value"})
 
-    extra_keys_schema = Schema({or_rule: str}, ignore_extra_keys=True)
-    assert extra_keys_schema.validate({"test1": "value", "other-key": "value"})
-    assert extra_keys_schema.validate({"test2": "other_value"})
+    extra_keys_schema = Schema(
+        {or_rule: str}, ignore_extra_keys=True
+    )
+    assert extra_keys_schema.validate(
+        {"test1": "value", "other-key": "value"}
+    )
+    assert extra_keys_schema.validate(
+        {"test2": "other_value"}
+    )
     with SE:
-        extra_keys_schema.validate({"test1": "value", "test2": "other_value"})
+        extra_keys_schema.validate(
+            {"test1": "value", "test2": "other_value"}
+        )
 
 
 def test_test():
@@ -135,11 +173,24 @@ def test_test():
     def dict_keys(key, _list):
         return list(map(lambda d: d[key], _list))
 
-    schema = Schema(Const(And(Use(partial(dict_keys, "index")), unique_list)))
-    data = [{"index": 1, "value": "foo"}, {"index": 2, "value": "bar"}]
+    schema = Schema(
+        Const(
+            And(
+                Use(partial(dict_keys, "index")),
+                unique_list,
+            )
+        )
+    )
+    data = [
+        {"index": 1, "value": "foo"},
+        {"index": 2, "value": "bar"},
+    ]
     assert schema.validate(data) == data
 
-    bad_data = [{"index": 1, "value": "foo"}, {"index": 1, "value": "bar"}]
+    bad_data = [
+        {"index": 1, "value": "foo"},
+        {"index": 1, "value": "bar"},
+    ]
     with SE:
         schema.validate(bad_data)
 
@@ -151,19 +202,31 @@ def test_regex():
         Regex(r"bar").validate("afoot")
 
     # More complex case: validate string
-    assert Regex(r"^[a-z]+$").validate("letters") == "letters"
+    assert (
+        Regex(r"^[a-z]+$").validate("letters") == "letters"
+    )
     with SE:
-        Regex(r"^[a-z]+$").validate("letters + spaces") == "letters + spaces"
+        Regex(r"^[a-z]+$").validate(
+            "letters + spaces"
+        ) == "letters + spaces"
 
     # Validate dict key
-    assert Schema({Regex(r"^foo"): str}).validate({"fookey": "value"}) == {"fookey": "value"}
+    assert Schema({Regex(r"^foo"): str}).validate(
+        {"fookey": "value"}
+    ) == {"fookey": "value"}
     with SE:
-        Schema({Regex(r"^foo"): str}).validate({"barkey": "value"})
+        Schema({Regex(r"^foo"): str}).validate(
+            {"barkey": "value"}
+        )
 
     # Validate dict value
-    assert Schema({str: Regex(r"^foo")}).validate({"key": "foovalue"}) == {"key": "foovalue"}
+    assert Schema({str: Regex(r"^foo")}).validate(
+        {"key": "foovalue"}
+    ) == {"key": "foovalue"}
     with SE:
-        Schema({str: Regex(r"^foo")}).validate({"key": "barvalue"})
+        Schema({str: Regex(r"^foo")}).validate(
+            {"key": "barvalue"}
+        )
 
     # Error if the value does not have a buffer interface
     with SE:
@@ -176,7 +239,9 @@ def test_regex():
         Regex(r"bar").validate(None)
 
     # Validate that the pattern has a buffer interface
-    assert Regex(re.compile(r"foo")).validate("foo") == "foo"
+    assert (
+        Regex(re.compile(r"foo")).validate("foo") == "foo"
+    )
     assert Regex(unicode("foo")).validate("foo") == "foo"
     with raises(TypeError):
         Regex(1).validate("bar")
@@ -189,13 +254,20 @@ def test_regex():
 
 
 def test_validate_list():
-    assert Schema([1, 0]).validate([1, 0, 1, 1]) == [1, 0, 1, 1]
+    assert Schema([1, 0]).validate([1, 0, 1, 1]) == [
+        1,
+        0,
+        1,
+        1,
+    ]
     assert Schema([1, 0]).validate([]) == []
     with SE:
         Schema([1, 0]).validate(0)
     with SE:
         Schema([1, 0]).validate([2])
-    assert And([1, 0], lambda l: len(l) > 2).validate([0, 1, 0]) == [0, 1, 0]
+    assert And([1, 0], lambda l: len(l) > 2).validate(
+        [0, 1, 0]
+    ) == [0, 1, 0]
     with SE:
         And([1, 0], lambda l: len(l) > 2).validate([0, 1])
 
@@ -204,12 +276,16 @@ def test_list_tuple_set_frozenset():
     assert Schema([int]).validate([1, 2])
     with SE:
         Schema([int]).validate(["1", 2])
-    assert Schema(set([int])).validate(set([1, 2])) == set([1, 2])
+    assert Schema(set([int])).validate(set([1, 2])) == set(
+        [1, 2]
+    )
     with SE:
         Schema(set([int])).validate([1, 2])  # not a set
     with SE:
         Schema(set([int])).validate(["1", 2])
-    assert Schema(tuple([int])).validate(tuple([1, 2])) == tuple([1, 2])
+    assert Schema(tuple([int])).validate(
+        tuple([1, 2])
+    ) == tuple([1, 2])
     with SE:
         Schema(tuple([int])).validate([1, 2])  # not a set
 
@@ -221,20 +297,30 @@ def test_strictly():
 
 
 def test_dict():
-    assert Schema({"key": 5}).validate({"key": 5}) == {"key": 5}
+    assert Schema({"key": 5}).validate({"key": 5}) == {
+        "key": 5
+    }
     with SE:
         Schema({"key": 5}).validate({"key": "x"})
     with SE:
         Schema({"key": 5}).validate(["key", 5])
-    assert Schema({"key": int}).validate({"key": 5}) == {"key": 5}
-    assert Schema({"n": int, "f": float}).validate({"n": 5, "f": 3.14}) == {"n": 5, "f": 3.14}
+    assert Schema({"key": int}).validate({"key": 5}) == {
+        "key": 5
+    }
+    assert Schema({"n": int, "f": float}).validate(
+        {"n": 5, "f": 3.14}
+    ) == {"n": 5, "f": 3.14}
     with SE:
-        Schema({"n": int, "f": float}).validate({"n": 3.14, "f": 5})
+        Schema({"n": int, "f": float}).validate(
+            {"n": 3.14, "f": 5}
+        )
     with SE:
         try:
             Schema({}).validate({"abc": None, 1: None})
         except SchemaWrongKeyError as e:
-            assert e.args[0].startswith("Wrong keys 'abc', 1 in")
+            assert e.args[0].startswith(
+                "Wrong keys 'abc', 1 in"
+            )
             raise
     with SE:
         try:
@@ -252,7 +338,9 @@ def test_dict():
         try:
             Schema({"key": 5, "key2": 5}).validate({"n": 5})
         except SchemaMissingKeyError as e:
-            assert e.args[0] == "Missing keys: 'key', 'key2'"
+            assert (
+                e.args[0] == "Missing keys: 'key', 'key2'"
+            )
             raise
     with SE:
         try:
@@ -262,92 +350,160 @@ def test_dict():
             raise
     with SE:
         try:
-            Schema({"key": 5}).validate({"key": 5, "bad": 5})
+            Schema({"key": 5}).validate(
+                {"key": 5, "bad": 5}
+            )
         except SchemaWrongKeyError as e:
-            assert e.args[0] in ["Wrong key 'bad' in {'key': 5, 'bad': 5}", "Wrong key 'bad' in {'bad': 5, 'key': 5}"]
+            assert e.args[0] in [
+                "Wrong key 'bad' in {'key': 5, 'bad': 5}",
+                "Wrong key 'bad' in {'bad': 5, 'key': 5}",
+            ]
             raise
     with SE:
         try:
             Schema({}).validate({"a": 5, "b": 5})
         except SchemaError as e:
-            assert e.args[0] in ["Wrong keys 'a', 'b' in {'a': 5, 'b': 5}", "Wrong keys 'a', 'b' in {'b': 5, 'a': 5}"]
+            assert e.args[0] in [
+                "Wrong keys 'a', 'b' in {'a': 5, 'b': 5}",
+                "Wrong keys 'a', 'b' in {'b': 5, 'a': 5}",
+            ]
             raise
 
     with SE:
         try:
             Schema({int: int}).validate({"": ""})
         except SchemaUnexpectedTypeError as e:
-            assert e.args[0] in ["'' should be instance of 'int'"]
+            assert e.args[0] in [
+                "'' should be instance of 'int'"
+            ]
 
 
 def test_dict_keys():
-    assert Schema({str: int}).validate({"a": 1, "b": 2}) == {"a": 1, "b": 2}
+    assert Schema({str: int}).validate(
+        {"a": 1, "b": 2}
+    ) == {"a": 1, "b": 2}
     with SE:
         Schema({str: int}).validate({1: 1, "b": 2})
-    assert Schema({Use(str): Use(int)}).validate({1: 3.14, 3.14: 1}) == {"1": 3, "3.14": 1}
+    assert Schema({Use(str): Use(int)}).validate(
+        {1: 3.14, 3.14: 1}
+    ) == {"1": 3, "3.14": 1}
 
 
 def test_ignore_extra_keys():
-    assert Schema({"key": 5}, ignore_extra_keys=True).validate({"key": 5, "bad": 4}) == {"key": 5}
-    assert Schema({"key": 5, "dk": {"a": "a"}}, ignore_extra_keys=True).validate(
+    assert Schema(
+        {"key": 5}, ignore_extra_keys=True
+    ).validate({"key": 5, "bad": 4}) == {"key": 5}
+    assert Schema(
+        {"key": 5, "dk": {"a": "a"}}, ignore_extra_keys=True
+    ).validate(
         {"key": 5, "bad": "b", "dk": {"a": "a", "bad": "b"}}
-    ) == {"key": 5, "dk": {"a": "a"}}
-    assert Schema([{"key": "v"}], ignore_extra_keys=True).validate([{"key": "v", "bad": "bad"}]) == [{"key": "v"}]
-    assert Schema([{"key": "v"}], ignore_extra_keys=True).validate([{"key": "v", "bad": "bad"}]) == [{"key": "v"}]
+    ) == {
+        "key": 5,
+        "dk": {"a": "a"},
+    }
+    assert Schema(
+        [{"key": "v"}], ignore_extra_keys=True
+    ).validate([{"key": "v", "bad": "bad"}]) == [
+        {"key": "v"}
+    ]
+    assert Schema(
+        [{"key": "v"}], ignore_extra_keys=True
+    ).validate([{"key": "v", "bad": "bad"}]) == [
+        {"key": "v"}
+    ]
 
 
 def test_ignore_extra_keys_validation_and_return_keys():
-    assert Schema({"key": 5, object: object}, ignore_extra_keys=True).validate({"key": 5, "bad": 4}) == {
-        "key": 5,
-        "bad": 4,
-    }
-    assert Schema({"key": 5, "dk": {"a": "a", object: object}}, ignore_extra_keys=True).validate(
+    assert Schema(
+        {"key": 5, object: object}, ignore_extra_keys=True
+    ).validate({"key": 5, "bad": 4}) == {"key": 5, "bad": 4}
+    assert Schema(
+        {"key": 5, "dk": {"a": "a", object: object}},
+        ignore_extra_keys=True,
+    ).validate(
         {"key": 5, "dk": {"a": "a", "bad": "b"}}
-    ) == {"key": 5, "dk": {"a": "a", "bad": "b"}}
+    ) == {
+        "key": 5,
+        "dk": {"a": "a", "bad": "b"},
+    }
 
 
 def test_dict_forbidden_keys():
     with raises(SchemaForbiddenKeyError):
-        Schema({Forbidden("b"): object}).validate({"b": "bye"})
+        Schema({Forbidden("b"): object}).validate(
+            {"b": "bye"}
+        )
     with raises(SchemaWrongKeyError):
         Schema({Forbidden("b"): int}).validate({"b": "bye"})
-    assert Schema({Forbidden("b"): int, Optional("b"): object}).validate({"b": "bye"}) == {"b": "bye"}
+    assert Schema(
+        {Forbidden("b"): int, Optional("b"): object}
+    ).validate({"b": "bye"}) == {"b": "bye"}
     with raises(SchemaForbiddenKeyError):
-        Schema({Forbidden("b"): object, Optional("b"): object}).validate({"b": "bye"})
+        Schema(
+            {Forbidden("b"): object, Optional("b"): object}
+        ).validate({"b": "bye"})
 
 
 def test_dict_hook():
     function_mock = Mock(return_value=None)
     hook = Hook("b", handler=function_mock)
 
-    assert Schema({hook: str, Optional("b"): object}).validate({"b": "bye"}) == {"b": "bye"}
+    assert Schema(
+        {hook: str, Optional("b"): object}
+    ).validate({"b": "bye"}) == {"b": "bye"}
     function_mock.assert_called_once()
 
-    assert Schema({hook: int, Optional("b"): object}).validate({"b": "bye"}) == {"b": "bye"}
+    assert Schema(
+        {hook: int, Optional("b"): object}
+    ).validate({"b": "bye"}) == {"b": "bye"}
     function_mock.assert_called_once()
 
-    assert Schema({hook: str, "b": object}).validate({"b": "bye"}) == {"b": "bye"}
+    assert Schema({hook: str, "b": object}).validate(
+        {"b": "bye"}
+    ) == {"b": "bye"}
     assert function_mock.call_count == 2
 
 
 def test_dict_optional_keys():
     with SE:
         Schema({"a": 1, "b": 2}).validate({"a": 1})
-    assert Schema({"a": 1, Optional("b"): 2}).validate({"a": 1}) == {"a": 1}
-    assert Schema({"a": 1, Optional("b"): 2}).validate({"a": 1, "b": 2}) == {"a": 1, "b": 2}
+    assert Schema({"a": 1, Optional("b"): 2}).validate(
+        {"a": 1}
+    ) == {"a": 1}
+    assert Schema({"a": 1, Optional("b"): 2}).validate(
+        {"a": 1, "b": 2}
+    ) == {"a": 1, "b": 2}
     # Make sure Optionals are favored over types:
-    assert Schema({basestring: 1, Optional("b"): 2}).validate({"a": 1, "b": 2}) == {"a": 1, "b": 2}
+    assert Schema(
+        {basestring: 1, Optional("b"): 2}
+    ).validate({"a": 1, "b": 2}) == {"a": 1, "b": 2}
     # Make sure Optionals hash based on their key:
-    assert len({Optional("a"): 1, Optional("a"): 1, Optional("b"): 2}) == 2
+    assert (
+        len(
+            {
+                Optional("a"): 1,
+                Optional("a"): 1,
+                Optional("b"): 2,
+            }
+        )
+        == 2
+    )
 
 
 def test_dict_optional_defaults():
     # Optionals fill out their defaults:
-    assert Schema({Optional("a", default=1): 11, Optional("b", default=2): 22}).validate({"a": 11}) == {"a": 11, "b": 2}
+    assert Schema(
+        {
+            Optional("a", default=1): 11,
+            Optional("b", default=2): 22,
+        }
+    ).validate({"a": 11}) == {"a": 11, "b": 2}
 
     # Optionals take precedence over types. Here, the "a" is served by the
     # Optional:
-    assert Schema({Optional("a", default=1): 11, basestring: 22}).validate({"b": 22}) == {"a": 1, "b": 22}
+    assert Schema(
+        {Optional("a", default=1): 11, basestring: 22}
+    ).validate({"b": 22}) == {"a": 1, "b": 22}
 
     with raises(TypeError):
         Optional(And(str, Use(int)), default=7)
@@ -366,14 +522,21 @@ def test_dict_key_error():
     try:
         Schema({"k": int}).validate({"k": "x"})
     except SchemaError as e:
-        assert e.code == "Key 'k' error:\n'x' should be instance of 'int'"
+        assert (
+            e.code
+            == "Key 'k' error:\n'x' should be instance of 'int'"
+        )
     try:
-        Schema({"k": {"k2": int}}).validate({"k": {"k2": "x"}})
+        Schema({"k": {"k2": int}}).validate(
+            {"k": {"k2": "x"}}
+        )
     except SchemaError as e:
         code = "Key 'k' error:\nKey 'k2' error:\n'x' should be instance of 'int'"
         assert e.code == code
     try:
-        Schema({"k": {"k2": int}}, error="k2 should be int").validate({"k": {"k2": "x"}})
+        Schema(
+            {"k": {"k2": int}}, error="k2 should be int"
+        ).validate({"k": {"k2": "x"}})
     except SchemaError as e:
         assert e.code == "k2 should be int"
 
@@ -383,10 +546,14 @@ def test_complex():
         {
             "<file>": And([Use(open)], lambda l: len(l)),
             "<path>": os.path.exists,
-            Optional("--count"): And(int, lambda n: 0 <= n <= 5),
+            Optional("--count"): And(
+                int, lambda n: 0 <= n <= 5
+            ),
         }
     )
-    data = s.validate({"<file>": ["./LICENSE-MIT"], "<path>": "./"})
+    data = s.validate(
+        {"<file>": ["./LICENSE-MIT"], "<path>": "./"}
+    )
     assert len(data) == 2
     assert len(data["<file>"]) == 1
     assert data["<file>"][0].read().startswith("Copyright")
@@ -399,11 +566,19 @@ def test_nice_errors():
     except SchemaError as e:
         assert e.errors == ["should be integer"]
     try:
-        Schema(Use(float), error="should be a number").validate("x")
+        Schema(
+            Use(float), error="should be a number"
+        ).validate("x")
     except SchemaError as e:
         assert e.code == "should be a number"
     try:
-        Schema({Optional("i"): Use(int, error="should be a number")}).validate({"i": "x"})
+        Schema(
+            {
+                Optional("i"): Use(
+                    int, error="should be a number"
+                )
+            }
+        ).validate({"i": "x"})
     except SchemaError as e:
         assert e.code == "should be a number"
 
@@ -447,16 +622,25 @@ def test_or_error_handling():
         assert e.autos[0].endswith(") did not validate 'x'")
         assert e.autos[1] == "ve('x') raised ValueError()"
         assert len(e.autos) == 2
-        assert e.errors == ["should not raise", "should not raise"]
+        assert e.errors == [
+            "should not raise",
+            "should not raise",
+        ]
     try:
         Or("o").validate("x")
     except SchemaError as e:
-        assert e.autos == ["Or('o') did not validate 'x'", "'o' does not match 'x'"]
+        assert e.autos == [
+            "Or('o') did not validate 'x'",
+            "'o' does not match 'x'",
+        ]
         assert e.errors == [None, None]
     try:
         Or("o", error="second error").validate("x")
     except SchemaError as e:
-        assert e.autos == ["Or('o') did not validate 'x'", "'o' does not match 'x'"]
+        assert e.autos == [
+            "Or('o') did not validate 'x'",
+            "'o' does not match 'x'",
+        ]
         assert e.errors == ["second error", "second error"]
 
 
@@ -487,12 +671,20 @@ def test_schema_error_handling():
     try:
         Schema(Use(ve)).validate("x")
     except SchemaError as e:
-        assert e.autos == [None, "ve('x') raised ValueError()"]
+        assert e.autos == [
+            None,
+            "ve('x') raised ValueError()",
+        ]
         assert e.errors == [None, None]
     try:
-        Schema(Use(ve), error="should not raise").validate("x")
+        Schema(Use(ve), error="should not raise").validate(
+            "x"
+        )
     except SchemaError as e:
-        assert e.autos == [None, "ve('x') raised ValueError()"]
+        assert e.autos == [
+            None,
+            "ve('x') raised ValueError()",
+        ]
         assert e.errors == ["should not raise", None]
     try:
         Schema(Use(se)).validate("x")
@@ -503,7 +695,11 @@ def test_schema_error_handling():
         Schema(Use(se), error="second error").validate("x")
     except SchemaError as e:
         assert e.autos == [None, None, "first auto"]
-        assert e.errors == ["second error", None, "first error"]
+        assert e.errors == [
+            "second error",
+            None,
+            "first error",
+        ]
 
 
 def test_use_json():
@@ -512,7 +708,13 @@ def test_use_json():
     gist_schema = Schema(
         And(
             Use(json.loads),  # first convert from JSON
-            {Optional("description"): basestring, "public": bool, "files": {basestring: {"content": basestring}}},
+            {
+                Optional("description"): basestring,
+                "public": bool,
+                "files": {
+                    basestring: {"content": basestring}
+                },
+            },
         )
     )
     gist = """{"description": "the description for this gist",
@@ -526,26 +728,57 @@ def test_use_json():
 def test_error_reporting():
     s = Schema(
         {
-            "<files>": [Use(open, error="<files> should be readable")],
-            "<path>": And(os.path.exists, error="<path> should exist"),
-            "--count": Or(None, And(Use(int), lambda n: 0 < n < 5), error="--count should be integer 0 < n < 5"),
+            "<files>": [
+                Use(
+                    open, error="<files> should be readable"
+                )
+            ],
+            "<path>": And(
+                os.path.exists, error="<path> should exist"
+            ),
+            "--count": Or(
+                None,
+                And(Use(int), lambda n: 0 < n < 5),
+                error="--count should be integer 0 < n < 5",
+            ),
         },
         error="Error:",
     )
-    s.validate({"<files>": [], "<path>": "./", "--count": 3})
+    s.validate(
+        {"<files>": [], "<path>": "./", "--count": 3}
+    )
 
     try:
-        s.validate({"<files>": [], "<path>": "./", "--count": "10"})
+        s.validate(
+            {"<files>": [], "<path>": "./", "--count": "10"}
+        )
     except SchemaError as e:
-        assert e.code == "Error:\n--count should be integer 0 < n < 5"
+        assert (
+            e.code
+            == "Error:\n--count should be integer 0 < n < 5"
+        )
     try:
-        s.validate({"<files>": [], "<path>": "./hai", "--count": "2"})
+        s.validate(
+            {
+                "<files>": [],
+                "<path>": "./hai",
+                "--count": "2",
+            }
+        )
     except SchemaError as e:
         assert e.code == "Error:\n<path> should exist"
     try:
-        s.validate({"<files>": ["hai"], "<path>": "./", "--count": "2"})
+        s.validate(
+            {
+                "<files>": ["hai"],
+                "<path>": "./",
+                "--count": "2",
+            }
+        )
     except SchemaError as e:
-        assert e.code == "Error:\n<files> should be readable"
+        assert (
+            e.code == "Error:\n<files> should be readable"
+        )
 
 
 def test_schema_repr():  # what about repr with `error`s?
@@ -564,7 +797,10 @@ def test_validate_object():
 
 def test_issue_9_prioritized_key_comparison():
     validate = Schema({"key": 42, object: 42}).validate
-    assert validate({"key": 42, 777: 42}) == {"key": 42, 777: 42}
+    assert validate({"key": 42, 777: 42}) == {
+        "key": 42,
+        777: 42,
+    }
 
 
 def test_issue_9_prioritized_key_comparison_in_dicts():
@@ -572,18 +808,28 @@ def test_issue_9_prioritized_key_comparison_in_dicts():
     s = Schema(
         {
             "ID": Use(int, error="ID should be an int"),
-            "FILE": Or(None, Use(open, error="FILE should be readable")),
+            "FILE": Or(
+                None,
+                Use(open, error="FILE should be readable"),
+            ),
             Optional(str): object,
         }
     )
-    data = {"ID": 10, "FILE": None, "other": "other", "other2": "other2"}
+    data = {
+        "ID": 10,
+        "FILE": None,
+        "other": "other",
+        "other2": "other2",
+    }
     assert s.validate(data) == data
     data = {"ID": 10, "FILE": None}
     assert s.validate(data) == data
 
 
 def test_missing_keys_exception_with_non_str_dict_keys():
-    s = Schema({And(str, Use(str.lower), "name"): And(str, len)})
+    s = Schema(
+        {And(str, Use(str.lower), "name"): And(str, len)}
+    )
     with SE:
         s.validate(dict())
     with SE:
@@ -595,7 +841,10 @@ def test_missing_keys_exception_with_non_str_dict_keys():
 
 
 # PyPy does have a __name__ attribute for its callables.
-@mark.skipif(platform.python_implementation() == "PyPy", reason="Running on PyPy")
+@mark.skipif(
+    platform.python_implementation() == "PyPy",
+    reason="Running on PyPy",
+)
 def test_issue_56_cant_rely_on_callables_to_have_name():
     s = Schema(methodcaller("endswith", ".csv"))
     assert s.validate("test.csv") == "test.csv"
@@ -642,7 +891,10 @@ def test_optional_key_convert_failed_randomly_while_with_another_optional_object
     import datetime
 
     fmt = "%Y-%m-%d %H:%M:%S"
-    _datetime_validator = Or(None, Use(lambda i: datetime.datetime.strptime(i, fmt)))
+    _datetime_validator = Or(
+        None,
+        Use(lambda i: datetime.datetime.strptime(i, fmt)),
+    )
     # FIXME given tests enough
     for i in range(1024):
         s = Schema(
@@ -657,7 +909,9 @@ def test_optional_key_convert_failed_randomly_while_with_another_optional_object
         validated_data = s.validate(data)
         # is expected to be converted to a datetime instance, but fails randomly
         # (most of the time)
-        assert isinstance(validated_data["created_at"], datetime.datetime)
+        assert isinstance(
+            validated_data["created_at"], datetime.datetime
+        )
         # assert isinstance(validated_data['created_at'], basestring)
 
 
@@ -676,12 +930,18 @@ def test_inheritance():
 
     class MySchema(Schema):
         def validate(self, data):
-            return super(MySchema, self).validate(convert(data))
+            return super(MySchema, self).validate(
+                convert(data)
+            )
 
     s = {"k": int, "d": {"k": int, "l": [{"l": [int]}]}}
     v = {"k": 1, "d": {"k": 2, "l": [{"l": [3, 4, 5]}]}}
     d = MySchema(s).validate(v)
-    assert d["k"] == 2 and d["d"]["k"] == 3 and d["d"]["l"][0]["l"] == [4, 5, 6]
+    assert (
+        d["k"] == 2
+        and d["d"]["k"] == 3
+        and d["d"]["l"][0]["l"] == [4, 5, 6]
+    )
 
 
 def test_json_schema():
@@ -747,7 +1007,9 @@ def test_json_schema_other_types():
 
 
 def test_json_schema_nested():
-    s = Schema({"test": {"other": str}}, ignore_extra_keys=True)
+    s = Schema(
+        {"test": {"other": str}}, ignore_extra_keys=True
+    )
     assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "id": "my-id",
@@ -766,7 +1028,13 @@ def test_json_schema_nested():
 
 
 def test_json_schema_nested_schema():
-    s = Schema({"test": Schema({"other": str}, ignore_extra_keys=True)})
+    s = Schema(
+        {
+            "test": Schema(
+                {"other": str}, ignore_extra_keys=True
+            )
+        }
+    )
     assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "id": "my-id",
@@ -820,7 +1088,10 @@ def test_json_schema_or_key():
     assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "id": "my-id",
-        "properties": {"test1": {"type": "string"}, "test2": {"type": "string"}},
+        "properties": {
+            "test1": {"type": "string"},
+            "test2": {"type": "string"},
+        },
         "required": [],
         "additionalProperties": False,
         "type": "object",
@@ -832,7 +1103,9 @@ def test_json_schema_or_values():
     assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "id": "my-id",
-        "properties": {"param": {"enum": ["test1", "test2"]}},
+        "properties": {
+            "param": {"enum": ["test1", "test2"]}
+        },
         "required": ["param"],
         "additionalProperties": False,
         "type": "object",
@@ -846,7 +1119,16 @@ def test_json_schema_or_values_nested():
         "id": "my-id",
         "properties": {
             "param": {
-                "anyOf": [{"type": "array", "items": {"type": "string"}}, {"type": "array", "items": {"type": "array"}}]
+                "anyOf": [
+                    {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    {
+                        "type": "array",
+                        "items": {"type": "array"},
+                    },
+                ]
             }
         },
         "required": ["param"],
@@ -860,7 +1142,9 @@ def test_json_schema_or_values_with_optional():
     assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "id": "my-id",
-        "properties": {"whatever": {"enum": ["test1", "test2"]}},
+        "properties": {
+            "whatever": {"enum": ["test1", "test2"]}
+        },
         "required": [],
         "additionalProperties": False,
         "type": "object",
@@ -868,11 +1152,22 @@ def test_json_schema_or_values_with_optional():
 
 
 def test_json_schema_regex():
-    s = Schema({Optional("username"): Regex("[a-zA-Z][a-zA-Z0-9]{3,}")})
+    s = Schema(
+        {
+            Optional("username"): Regex(
+                "[a-zA-Z][a-zA-Z0-9]{3,}"
+            )
+        }
+    )
     assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "id": "my-id",
-        "properties": {"username": {"type": "string", "pattern": "[a-zA-Z][a-zA-Z0-9]{3,}"}},
+        "properties": {
+            "username": {
+                "type": "string",
+                "pattern": "[a-zA-Z][a-zA-Z0-9]{3,}",
+            }
+        },
         "required": [],
         "additionalProperties": False,
         "type": "object",
@@ -884,7 +1179,14 @@ def test_json_schema_or_types():
     assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "id": "my-id",
-        "properties": {"test": {"anyOf": [{"type": "string"}, {"type": "integer"}]}},
+        "properties": {
+            "test": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "integer"},
+                ]
+            }
+        },
         "required": ["test"],
         "additionalProperties": False,
         "type": "object",
@@ -897,7 +1199,9 @@ def test_json_schema_and_types():
     assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "id": "my-id",
-        "properties": {"test": {"allOf": [{"type": "string"}]}},
+        "properties": {
+            "test": {"allOf": [{"type": "string"}]}
+        },
         "required": ["test"],
         "additionalProperties": False,
         "type": "object",
@@ -928,7 +1232,10 @@ def test_json_schema_object_or_array_of_object():
                 "anyOf": [
                     {
                         "additionalProperties": False,
-                        "properties": {"param1": {"const": "test1"}, "param2": {"const": "test2"}},
+                        "properties": {
+                            "param1": {"const": "test1"},
+                            "param2": {"const": "test2"},
+                        },
                         "required": ["param1"],
                         "type": "object",
                     },
@@ -936,7 +1243,14 @@ def test_json_schema_object_or_array_of_object():
                         "type": "array",
                         "items": {
                             "additionalProperties": False,
-                            "properties": {"param1": {"const": "test1"}, "param2": {"const": "test2"}},
+                            "properties": {
+                                "param1": {
+                                    "const": "test1"
+                                },
+                                "param2": {
+                                    "const": "test2"
+                                },
+                            },
                             "required": ["param1"],
                             "type": "object",
                         },
@@ -955,7 +1269,14 @@ def test_json_schema_and_simple():
     assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "id": "my-id",
-        "properties": {"test1": {"allOf": [{"type": "string"}, {"const": "test2"}]}},
+        "properties": {
+            "test1": {
+                "allOf": [
+                    {"type": "string"},
+                    {"const": "test2"},
+                ]
+            }
+        },
         "required": ["test1"],
         "additionalProperties": False,
         "type": "object",
@@ -963,12 +1284,24 @@ def test_json_schema_and_simple():
 
 
 def test_json_schema_and_list():
-    s = Schema({"param1": And(["choice1", "choice2"], list)})
+    s = Schema(
+        {"param1": And(["choice1", "choice2"], list)}
+    )
     assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "id": "my-id",
         "properties": {
-            "param1": {"allOf": [{"type": "array", "items": {"enum": ["choice1", "choice2"]}}, {"type": "array"}]}
+            "param1": {
+                "allOf": [
+                    {
+                        "type": "array",
+                        "items": {
+                            "enum": ["choice1", "choice2"]
+                        },
+                    },
+                    {"type": "array"},
+                ]
+            }
         },
         "required": ["param1"],
         "additionalProperties": False,
@@ -1001,7 +1334,16 @@ def test_json_schema_not_a_dict():
 
 
 def test_json_schema_title_and_description():
-    s = Schema({Literal("productId", description="The unique identifier for a product"): int}, name="Product", description="A product in the catalog")
+    s = Schema(
+        {
+            Literal(
+                "productId",
+                description="The unique identifier for a product",
+            ): int
+        },
+        name="Product",
+        description="A product in the catalog",
+    )
     assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "id": "my-id",
@@ -1010,7 +1352,7 @@ def test_json_schema_title_and_description():
         "properties": {
             "productId": {
                 "description": "The unique identifier for a product",
-                "type": "integer"
+                "type": "integer",
             }
         },
         "required": ["productId"],
@@ -1020,7 +1362,17 @@ def test_json_schema_title_and_description():
 
 
 def test_json_schema_description_nested():
-    s = Schema({Optional(Literal("test1", description="A description here"), default={}): Or([str], [list])})
+    s = Schema(
+        {
+            Optional(
+                Literal(
+                    "test1",
+                    description="A description here",
+                ),
+                default={},
+            ): Or([str], [list])
+        }
+    )
     assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "id": "my-id",
@@ -1029,18 +1381,14 @@ def test_json_schema_description_nested():
                 "description": "A description here",
                 "anyOf": [
                     {
-                        "items": {
-                            "type": "string"
-                        },
+                        "items": {"type": "string"},
                         "type": "array",
                     },
                     {
-                        "items": {
-                            "type": "array"
-                        },
+                        "items": {"type": "array"},
                         "type": "array",
-                    }
-                ]
+                    },
+                ],
             }
         },
         "required": [],
@@ -1050,118 +1398,145 @@ def test_json_schema_description_nested():
 
 
 def test_json_schema_description_or_nested():
-    s = Schema({Optional(Or(Literal("test1", description="A description here"), Literal("test2", description="Another"))): Or([str], [list])})
-    assert s.json_schema("my-id") == {
-      "type": "object",
-      "properties": {
-        "test1": {
-          "description": "A description here",
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "items": {
-                "type": "array"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "test2": {
-          "description": "Another",
-          "anyOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "items": {
-                "type": "array"
-              },
-              "type": "array"
-            }
-          ]
+    s = Schema(
+        {
+            Optional(
+                Or(
+                    Literal(
+                        "test1",
+                        description="A description here",
+                    ),
+                    Literal("test2", description="Another"),
+                )
+            ): Or([str], [list])
         }
-      },
-      "required": [],
-      "additionalProperties": False,
-      "id": "my-id",
-      "$schema": "http://json-schema.org/draft-07/schema#"
+    )
+    assert s.json_schema("my-id") == {
+        "type": "object",
+        "properties": {
+            "test1": {
+                "description": "A description here",
+                "anyOf": [
+                    {
+                        "items": {"type": "string"},
+                        "type": "array",
+                    },
+                    {
+                        "items": {"type": "array"},
+                        "type": "array",
+                    },
+                ],
+            },
+            "test2": {
+                "description": "Another",
+                "anyOf": [
+                    {
+                        "items": {"type": "string"},
+                        "type": "array",
+                    },
+                    {
+                        "items": {"type": "array"},
+                        "type": "array",
+                    },
+                ],
+            },
+        },
+        "required": [],
+        "additionalProperties": False,
+        "id": "my-id",
+        "$schema": "http://json-schema.org/draft-07/schema#",
     }
 
 
 def test_json_schema_description_and_nested():
-    s = Schema({Optional(Or(Literal("test1", description="A description here"), Literal("test2", description="Another"))): And([str], [list])})
-    assert s.json_schema("my-id") == {
-      "type": "object",
-      "properties": {
-        "test1": {
-          "description": "A description here",
-          "allOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "items": {
-                "type": "array"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "test2": {
-          "description": "Another",
-          "allOf": [
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "items": {
-                "type": "array"
-              },
-              "type": "array"
-            }
-          ]
+    s = Schema(
+        {
+            Optional(
+                Or(
+                    Literal(
+                        "test1",
+                        description="A description here",
+                    ),
+                    Literal("test2", description="Another"),
+                )
+            ): And([str], [list])
         }
-      },
-      "required": [],
-      "additionalProperties": False,
-      "id": "my-id",
-      "$schema": "http://json-schema.org/draft-07/schema#"
+    )
+    assert s.json_schema("my-id") == {
+        "type": "object",
+        "properties": {
+            "test1": {
+                "description": "A description here",
+                "allOf": [
+                    {
+                        "items": {"type": "string"},
+                        "type": "array",
+                    },
+                    {
+                        "items": {"type": "array"},
+                        "type": "array",
+                    },
+                ],
+            },
+            "test2": {
+                "description": "Another",
+                "allOf": [
+                    {
+                        "items": {"type": "string"},
+                        "type": "array",
+                    },
+                    {
+                        "items": {"type": "array"},
+                        "type": "array",
+                    },
+                ],
+            },
+        },
+        "required": [],
+        "additionalProperties": False,
+        "id": "my-id",
+        "$schema": "http://json-schema.org/draft-07/schema#",
     }
 
 
 def test_description():
-    s = Schema({Optional(Literal("test1", description="A description here"), default={}): dict})
-    assert s.validate({
-        "test1": {}
-    })
+    s = Schema(
+        {
+            Optional(
+                Literal(
+                    "test1",
+                    description="A description here",
+                ),
+                default={},
+            ): dict
+        }
+    )
+    assert s.validate({"test1": {}})
 
 
 def test_prepend_schema_name():
     try:
         Schema({"key1": int}).validate({"key1": "a"})
     except SchemaError as e:
-        assert str(e) == "Key 'key1' error:\n'a' should be instance of 'int'"
+        assert (
+            str(e)
+            == "Key 'key1' error:\n'a' should be instance of 'int'"
+        )
 
     try:
-        Schema({"key1": int}, name="custom_schemaname").validate({"key1": "a"})
+        Schema(
+            {"key1": int}, name="custom_schemaname"
+        ).validate({"key1": "a"})
     except SchemaError as e:
-        assert str(e) == "'custom_schemaname' Key 'key1' error:\n'a' should be instance of 'int'"
+        assert (
+            str(e)
+            == "'custom_schemaname' Key 'key1' error:\n'a' should be instance of 'int'"
+        )
 
     try:
         Schema(int, name="custom_schemaname").validate("a")
     except SchemaUnexpectedTypeError as e:
-        assert str(e) == "'custom_schemaname' 'a' should be instance of 'int'"
+        assert (
+            str(e)
+            == "'custom_schemaname' 'a' should be instance of 'int'"
+        )


### PR DESCRIPTION
Another feature for #180 
 - Added the Literal type for adding a description to JSON schemas
 - Fixed new bugs introduced by the Literal type
 - Added tests to ensure the Literal type was working as expected 

This is a direct continuation to PR #206 
