### PR TITLE
Add references to JSON schema rendering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -509,7 +509,7 @@ Here's an example:
     >>> s = Schema({"test": str,
     ...             "nested": {Optional("other"): str}
     ...             })
-    >>> json_schema = json.dumps(s.json_schema("https://example.com/my-schema.json", no_refs=True))
+    >>> json_schema = json.dumps(s.json_schema("https://example.com/my-schema.json"))
 
     # json_schema
     {
@@ -534,8 +534,8 @@ Here's an example:
         "$schema":"http://json-schema.org/draft-07/schema#"
     }
 
-By default, in order to minimize the size of the output, the generated schema will use references to other parts of the schema. You can disable
-this behaviour by providing the parameter `no_refs` to the json_schema method.
-
 Please note that not all JSON schema validations are implemented. This includes features such as integers' minimum and maximum or
 arrays' minItems.
+
+In order to minimize the size of the output, the generated schema can be made to use references to other parts of the schema.
+Enable this behaviour by providing the parameter `use_refs` to the json_schema method.

--- a/README.rst
+++ b/README.rst
@@ -496,7 +496,7 @@ this is how you validate it using ``schema``:
 As you can see, **schema** validated data successfully, opened files and
 converted ``'3'`` to ``int``.
 
-(Beta feature) Generating JSON schema
+Generating JSON schema
 -------------------------------------------------------------------------------
 You can also generate standard `draft-07 JSON schema <https://json-schema.org/>`_ from a dict `Schema`.
 This can be used to add word completion and validation directly in code editors.
@@ -509,7 +509,7 @@ Here's an example:
     >>> s = Schema({"test": str,
     ...             "nested": {Optional("other"): str}
     ...             })
-    >>> json_schema = json.dumps(s.json_schema("https://example.com/my-schema.json"))
+    >>> json_schema = json.dumps(s.json_schema("https://example.com/my-schema.json", no_refs=True))
 
     # json_schema
     {
@@ -530,12 +530,12 @@ Here's an example:
             "nested"
         ],
         "additionalProperties":false,
-        "id":"https://example.com/my-schema.json",
+        "$id":"https://example.com/my-schema.json",
         "$schema":"http://json-schema.org/draft-07/schema#"
     }
 
-Please note that this is a beta feature. Some JSON schema features are not implemented. Some caveats:
+By default, in order to minimize the size of the output, the generated schema will use references to other parts of the schema. You can disable
+this behaviour by providing the parameter `no_refs` to the json_schema method.
 
-- There are no object references, items of type `object` are always fully rendered
-- Validations other than type are not implemented. This includes features such as integers'
-  minimum and maximum or arrays' minItems
+Please note that not all JSON schema validations are implemented. This includes features such as integers' minimum and maximum or
+arrays' minItems.

--- a/test_schema.py
+++ b/test_schema.py
@@ -686,9 +686,9 @@ def test_inheritance():
 
 def test_json_schema():
     s = Schema({"test": str})
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {"test": {"type": "string"}},
         "required": ["test"],
         "additionalProperties": False,
@@ -698,9 +698,9 @@ def test_json_schema():
 
 def test_json_schema_with_title():
     s = Schema({"test": str}, name="Testing a schema")
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "title": "Testing a schema",
         "properties": {"test": {"type": "string"}},
         "required": ["test"],
@@ -718,9 +718,9 @@ def test_json_schema_types():
             Optional("test_bool"): bool,
         }
     )
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {
             "test_str": {"type": "string"},
             "test_int": {"type": "integer"},
@@ -736,9 +736,9 @@ def test_json_schema_types():
 def test_json_schema_other_types():
     """Test that data types not supported by JSON schema are returned as strings"""
     s = Schema({Optional("test_other"): bytes})
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {"test_other": {"type": "string"}},
         "required": [],
         "additionalProperties": False,
@@ -748,9 +748,9 @@ def test_json_schema_other_types():
 
 def test_json_schema_nested():
     s = Schema({"test": {"other": str}}, ignore_extra_keys=True)
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {
             "test": {
                 "type": "object",
@@ -767,9 +767,9 @@ def test_json_schema_nested():
 
 def test_json_schema_nested_schema():
     s = Schema({"test": Schema({"other": str}, ignore_extra_keys=True)})
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {
             "test": {
                 "type": "object",
@@ -786,9 +786,9 @@ def test_json_schema_nested_schema():
 
 def test_json_schema_optional_key():
     s = Schema({Optional("test"): str})
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {"test": {"type": "string"}},
         "required": [],
         "additionalProperties": False,
@@ -798,9 +798,9 @@ def test_json_schema_optional_key():
 
 def test_json_schema_optional_key_nested():
     s = Schema({"test": {Optional("other"): str}})
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {
             "test": {
                 "type": "object",
@@ -817,9 +817,9 @@ def test_json_schema_optional_key_nested():
 
 def test_json_schema_or_key():
     s = Schema({Or("test1", "test2"): str})
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {"test1": {"type": "string"}, "test2": {"type": "string"}},
         "required": [],
         "additionalProperties": False,
@@ -829,9 +829,9 @@ def test_json_schema_or_key():
 
 def test_json_schema_or_values():
     s = Schema({"param": Or("test1", "test2")})
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {"param": {"enum": ["test1", "test2"]}},
         "required": ["param"],
         "additionalProperties": False,
@@ -841,9 +841,9 @@ def test_json_schema_or_values():
 
 def test_json_schema_or_values_nested():
     s = Schema({"param": Or([str], [list])})
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {
             "param": {
                 "anyOf": [{"type": "array", "items": {"type": "string"}}, {"type": "array", "items": {"type": "array"}}]
@@ -857,9 +857,9 @@ def test_json_schema_or_values_nested():
 
 def test_json_schema_or_values_with_optional():
     s = Schema({Optional("whatever"): Or("test1", "test2")})
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {"whatever": {"enum": ["test1", "test2"]}},
         "required": [],
         "additionalProperties": False,
@@ -869,9 +869,9 @@ def test_json_schema_or_values_with_optional():
 
 def test_json_schema_regex():
     s = Schema({Optional("username"): Regex("[a-zA-Z][a-zA-Z0-9]{3,}")})
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {"username": {"type": "string", "pattern": "[a-zA-Z][a-zA-Z0-9]{3,}"}},
         "required": [],
         "additionalProperties": False,
@@ -881,9 +881,9 @@ def test_json_schema_regex():
 
 def test_json_schema_or_types():
     s = Schema({"test": Or(str, int)})
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {"test": {"anyOf": [{"type": "string"}, {"type": "integer"}]}},
         "required": ["test"],
         "additionalProperties": False,
@@ -894,9 +894,9 @@ def test_json_schema_or_types():
 def test_json_schema_and_types():
     # Can't determine the type, it will not be checked
     s = Schema({"test": And(str, lambda x: len(x) < 5)})
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {"test": {"allOf": [{"type": "string"}]}},
         "required": ["test"],
         "additionalProperties": False,
@@ -906,9 +906,9 @@ def test_json_schema_and_types():
 
 def test_json_schema_or_one_value():
     s = Schema({"test": Or(True)})
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {"test": {"const": True}},
         "required": ["test"],
         "additionalProperties": False,
@@ -920,9 +920,9 @@ def test_json_schema_object_or_array_of_object():
     # Complex test where "test" accepts either an object or an array of that object
     o = {"param1": "test1", Optional("param2"): "test2"}
     s = Schema({"test": Or(o, [o])})
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {
             "test": {
                 "anyOf": [
@@ -952,9 +952,9 @@ def test_json_schema_object_or_array_of_object():
 
 def test_json_schema_and_simple():
     s = Schema({"test1": And(str, "test2")})
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {"test1": {"allOf": [{"type": "string"}, {"const": "test2"}]}},
         "required": ["test1"],
         "additionalProperties": False,
@@ -964,9 +964,9 @@ def test_json_schema_and_simple():
 
 def test_json_schema_and_list():
     s = Schema({"param1": And(["choice1", "choice2"], list)})
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {
             "param1": {"allOf": [{"type": "array", "items": {"enum": ["choice1", "choice2"]}}, {"type": "array"}]}
         },
@@ -978,9 +978,9 @@ def test_json_schema_and_list():
 
 def test_json_schema_forbidden_key_ignored():
     s = Schema({Forbidden("forbidden"): str, "test": str})
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {"test": {"type": "string"}},
         "required": ["test"],
         "additionalProperties": False,
@@ -988,16 +988,10 @@ def test_json_schema_forbidden_key_ignored():
     }
 
 
-def test_json_schema_no_id():
-    s = Schema({"test": int})
-    with raises(ValueError):
-        s.json_schema()
-
-
 def test_json_schema_not_a_dict():
     s = Schema(int)
     with raises(ValueError):
-        s.json_schema()
+        s.json_schema("my-id")
 
 
 def test_json_schema_title_and_description():
@@ -1006,9 +1000,9 @@ def test_json_schema_title_and_description():
         name="Product",
         description="A product in the catalog",
     )
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "title": "Product",
         "description": "A product in the catalog",
         "properties": {"productId": {"description": "The unique identifier for a product", "type": "integer"}},
@@ -1020,9 +1014,9 @@ def test_json_schema_title_and_description():
 
 def test_json_schema_description_nested():
     s = Schema({Optional(Literal("test1", description="A description here"), default={}): Or([str], [list])})
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "id": "my-id",
+        "$id": "my-id",
         "properties": {
             "test1": {
                 "description": "A description here",
@@ -1046,7 +1040,7 @@ def test_json_schema_description_or_nested():
             ): Or([str], [list])
         }
     )
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "type": "object",
         "properties": {
             "test1": {
@@ -1066,7 +1060,7 @@ def test_json_schema_description_or_nested():
         },
         "required": [],
         "additionalProperties": False,
-        "id": "my-id",
+        "$id": "my-id",
         "$schema": "http://json-schema.org/draft-07/schema#",
     }
 
@@ -1079,7 +1073,7 @@ def test_json_schema_description_and_nested():
             ): And([str], [list])
         }
     )
-    assert s.json_schema("my-id") == {
+    assert s.json_schema("my-id", no_refs=True) == {
         "type": "object",
         "properties": {
             "test1": {
@@ -1099,7 +1093,7 @@ def test_json_schema_description_and_nested():
         },
         "required": [],
         "additionalProperties": False,
-        "id": "my-id",
+        "$id": "my-id",
         "$schema": "http://json-schema.org/draft-07/schema#",
     }
 
@@ -1107,6 +1101,33 @@ def test_json_schema_description_and_nested():
 def test_description():
     s = Schema({Optional(Literal("test1", description="A description here"), default={}): dict})
     assert s.validate({"test1": {}})
+
+
+def test_json_schema_refs():
+    s = Schema({"test1": str, "test2": str, "test3": str})
+    hashed = "#" + str(hash(repr(sorted({"type": "string"}.items()))))
+    generated_json_schema = s.json_schema("my-id")
+
+    # The order can change, so let's check indirectly
+    assert generated_json_schema["type"] == "object"
+    assert sorted(generated_json_schema["required"]) == ["test1", "test2", "test3"]
+    assert generated_json_schema["additionalProperties"] is False
+    assert generated_json_schema["$id"] == "my-id"
+    assert generated_json_schema["$schema"] == "http://json-schema.org/draft-07/schema#"
+
+    # There will be one of the property being the id and 2 referencing it, but which one is random
+    id_schema_part = {"type": "string", "$id": hashed}
+    ref_schema_part = {"$ref": hashed}
+
+    nb_id_schema = 0
+    nb_ref_schema = 0
+    for v in generated_json_schema["properties"].values():
+        if v == id_schema_part:
+            nb_id_schema += 1
+        elif v == ref_schema_part:
+            nb_ref_schema += 1
+    assert nb_id_schema == 1
+    assert nb_ref_schema == 2
 
 
 def test_prepend_schema_name():

--- a/test_schema.py
+++ b/test_schema.py
@@ -1,6 +1,7 @@
 from __future__ import with_statement
 
 import copy
+import json
 import os
 import platform
 import re
@@ -686,7 +687,7 @@ def test_inheritance():
 
 def test_json_schema():
     s = Schema({"test": str})
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {"test": {"type": "string"}},
@@ -698,7 +699,7 @@ def test_json_schema():
 
 def test_json_schema_with_title():
     s = Schema({"test": str}, name="Testing a schema")
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "title": "Testing a schema",
@@ -718,7 +719,7 @@ def test_json_schema_types():
             Optional("test_bool"): bool,
         }
     )
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {
@@ -736,7 +737,7 @@ def test_json_schema_types():
 def test_json_schema_other_types():
     """Test that data types not supported by JSON schema are returned as strings"""
     s = Schema({Optional("test_other"): bytes})
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {"test_other": {"type": "string"}},
@@ -748,7 +749,7 @@ def test_json_schema_other_types():
 
 def test_json_schema_nested():
     s = Schema({"test": {"other": str}}, ignore_extra_keys=True)
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {
@@ -767,7 +768,7 @@ def test_json_schema_nested():
 
 def test_json_schema_nested_schema():
     s = Schema({"test": Schema({"other": str}, ignore_extra_keys=True)})
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {
@@ -786,7 +787,7 @@ def test_json_schema_nested_schema():
 
 def test_json_schema_optional_key():
     s = Schema({Optional("test"): str})
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {"test": {"type": "string"}},
@@ -798,7 +799,7 @@ def test_json_schema_optional_key():
 
 def test_json_schema_optional_key_nested():
     s = Schema({"test": {Optional("other"): str}})
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {
@@ -817,7 +818,7 @@ def test_json_schema_optional_key_nested():
 
 def test_json_schema_or_key():
     s = Schema({Or("test1", "test2"): str})
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {"test1": {"type": "string"}, "test2": {"type": "string"}},
@@ -829,7 +830,7 @@ def test_json_schema_or_key():
 
 def test_json_schema_or_values():
     s = Schema({"param": Or("test1", "test2")})
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {"param": {"enum": ["test1", "test2"]}},
@@ -841,7 +842,7 @@ def test_json_schema_or_values():
 
 def test_json_schema_or_values_nested():
     s = Schema({"param": Or([str], [list])})
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {
@@ -857,7 +858,7 @@ def test_json_schema_or_values_nested():
 
 def test_json_schema_or_values_with_optional():
     s = Schema({Optional("whatever"): Or("test1", "test2")})
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {"whatever": {"enum": ["test1", "test2"]}},
@@ -869,7 +870,7 @@ def test_json_schema_or_values_with_optional():
 
 def test_json_schema_regex():
     s = Schema({Optional("username"): Regex("[a-zA-Z][a-zA-Z0-9]{3,}")})
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {"username": {"type": "string", "pattern": "[a-zA-Z][a-zA-Z0-9]{3,}"}},
@@ -881,7 +882,7 @@ def test_json_schema_regex():
 
 def test_json_schema_or_types():
     s = Schema({"test": Or(str, int)})
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {"test": {"anyOf": [{"type": "string"}, {"type": "integer"}]}},
@@ -894,7 +895,7 @@ def test_json_schema_or_types():
 def test_json_schema_and_types():
     # Can't determine the type, it will not be checked
     s = Schema({"test": And(str, lambda x: len(x) < 5)})
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {"test": {"allOf": [{"type": "string"}]}},
@@ -906,7 +907,7 @@ def test_json_schema_and_types():
 
 def test_json_schema_or_one_value():
     s = Schema({"test": Or(True)})
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {"test": {"const": True}},
@@ -920,7 +921,7 @@ def test_json_schema_object_or_array_of_object():
     # Complex test where "test" accepts either an object or an array of that object
     o = {"param1": "test1", Optional("param2"): "test2"}
     s = Schema({"test": Or(o, [o])})
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {
@@ -952,7 +953,7 @@ def test_json_schema_object_or_array_of_object():
 
 def test_json_schema_and_simple():
     s = Schema({"test1": And(str, "test2")})
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {"test1": {"allOf": [{"type": "string"}, {"const": "test2"}]}},
@@ -964,7 +965,7 @@ def test_json_schema_and_simple():
 
 def test_json_schema_and_list():
     s = Schema({"param1": And(["choice1", "choice2"], list)})
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {
@@ -978,7 +979,7 @@ def test_json_schema_and_list():
 
 def test_json_schema_forbidden_key_ignored():
     s = Schema({Forbidden("forbidden"): str, "test": str})
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {"test": {"type": "string"}},
@@ -1000,7 +1001,7 @@ def test_json_schema_title_and_description():
         name="Product",
         description="A product in the catalog",
     )
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "title": "Product",
@@ -1014,7 +1015,7 @@ def test_json_schema_title_and_description():
 
 def test_json_schema_description_nested():
     s = Schema({Optional(Literal("test1", description="A description here"), default={}): Or([str], [list])})
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {
@@ -1040,7 +1041,7 @@ def test_json_schema_description_or_nested():
             ): Or([str], [list])
         }
     )
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "type": "object",
         "properties": {
             "test1": {
@@ -1073,7 +1074,7 @@ def test_json_schema_description_and_nested():
             ): And([str], [list])
         }
     )
-    assert s.json_schema("my-id", no_refs=True) == {
+    assert s.json_schema("my-id") == {
         "type": "object",
         "properties": {
             "test1": {
@@ -1106,7 +1107,7 @@ def test_description():
 def test_json_schema_refs():
     s = Schema({"test1": str, "test2": str, "test3": str})
     hashed = "#" + str(hash(repr(sorted({"type": "string"}.items()))))
-    generated_json_schema = s.json_schema("my-id")
+    generated_json_schema = s.json_schema("my-id", use_refs=True)
 
     # The order can change, so let's check indirectly
     assert generated_json_schema["type"] == "object"
@@ -1128,6 +1129,48 @@ def test_json_schema_refs():
             nb_ref_schema += 1
     assert nb_id_schema == 1
     assert nb_ref_schema == 2
+
+
+def test_json_schema_refs_is_smaller():
+    key_names = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t"]
+    key_values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, "value1", "value2", "value3", "value4", "value5", None]
+    s = Schema({Literal(Or(*key_names), description="A key that can have many names"): key_values})
+    assert len(json.dumps(s.json_schema("my-id", use_refs=False))) > len(
+        json.dumps(s.json_schema("my-id", use_refs=True))
+    )
+
+
+def test_json_schema_refs_no_missing():
+    key_names = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t"]
+    key_values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, "value1", "value2", "value3", "value4", "value5", None]
+    s = Schema({Literal(Or(*key_names), description="A key that can have many names"): key_values})
+    json_s = s.json_schema("my-id", use_refs=True)
+    schema_ids = []
+    refs = []
+
+    def _get_ids_and_refs(schema_dict):
+        for k, v in schema_dict.items():
+            if isinstance(v, dict):
+                _get_ids_and_refs(v)
+                continue
+
+            if k == "$id" and v != "my-id":
+                schema_ids.append(v)
+            elif k == "$ref":
+                refs.append(v)
+
+    _get_ids_and_refs(json_s)
+
+    # No ID is repeated
+    assert len(schema_ids) == len(set(schema_ids))
+
+    # All IDs are used in a ref
+    for schema_id in schema_ids:
+        assert schema_id in refs
+
+    # All refs have an associated ID
+    for ref in refs:
+        assert ref in schema_ids
 
 
 def test_prepend_schema_name():


### PR DESCRIPTION
To reduce the size of the generated JSON schema, this PR adds setting an id for a part of the schema and then using the id as reference in other parts.

For our particular use case, the produced JSON schema decreased size from 54 MiB to 65 KiB using this feature.

Some caveats:
- The resulting schema is not the smallest it can be because of the way the tree is traversed. I tested different approaches to reduce it further, but thought that the added complexity and execution time was not worth the size reduction. In my above example, the size went down to 28 KiB with breadth-first traversal instead of 65 KiB with the implementation in this PR, still not a significant gain from the 54 MiB when not using references.
- This produces a single schema, not several files with references, [as is suggested here](https://json-schema.org/understanding-json-schema/structuring.html#reuse)
- The resulting schema is harder to read by a human. The id are hashes, not friendly names and the references are hard to follow. I don't think this is a big problem since this is more for machine consumption

I hesitated to set the `no_refs` parameter to True by default, since the resulting schema will be different (but still usable) from the previous versions. Is this a breaking change?