### PR TITLE
Fix error in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -310,6 +310,7 @@ In a dictionary, you can also combine two keys in a "one or the other" manner. T
 so, use the `Or` class as a key:
 
 .. code:: python
+
     >>> from schema import Or, Schema
     >>> schema = Schema({
     ...    Or("key1", "key2", only_one=True): str


### PR DESCRIPTION
I think this might make the readme render properly on PyPI

Before this fix, Sphinx says: "WARNING: Error in "code" directive: maximum 1 argument(s) allowed, 18 supplied."