### PR TITLE
JSON Schema: Fix using Literal in enum

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -520,11 +520,12 @@ class Schema(object):
 
                 # Check if we can use an enum
                 if all(priority == COMPARABLE for priority in [_priority(value) for value in s.args]):
+                    or_values = [str(s) if isinstance(s, Literal) else s for s in s.args]
                     # All values are simple, can use enum or const
-                    if len(s.args) == 1:
-                        return_schema["const"] = s.args[0]
+                    if len(or_values) == 1:
+                        return_schema["const"] = or_values[0]
                         return return_schema
-                    return_schema["enum"] = list(s.args)
+                    return_schema["enum"] = or_values
                 else:
                     # No enum, let's go with recursive calls
                     any_of_values = []
@@ -542,7 +543,7 @@ class Schema(object):
                         all_of_values.append(new_value)
                 return_schema["allOf"] = all_of_values
             elif flavor == COMPARABLE:
-                return_schema["const"] = s
+                return_schema["const"] = str(s)
             elif flavor == VALIDATOR and type(s) == Regex:
                 return_schema["type"] = "string"
                 return_schema["pattern"] = s.pattern_str
@@ -674,6 +675,9 @@ class Literal(object):
     def __init__(self, value, description=None):
         self._schema = value
         self._description = description
+
+    def __str__(self):
+        return self._schema
 
     @property
     def description(self):

--- a/schema.py
+++ b/schema.py
@@ -19,6 +19,7 @@ __all__ = [
     "Use",
     "Forbidden",
     "Const",
+    "Literal",
     "SchemaError",
     "SchemaWrongKeyError",
     "SchemaMissingKeyError",
@@ -334,6 +335,10 @@ class Schema(object):
         s = self._schema
         e = self._error
         i = self._ignore_extra_keys
+
+        if isinstance(s, Literal):
+            s = s.schema
+
         flavor = _priority(s)
         if flavor == ITERABLE:
             data = Schema(type(s), error=e).validate(data)
@@ -438,9 +443,6 @@ class Schema(object):
             raise SchemaError(message, e)
         if s == data:
             return data
-        if isinstance(s, Literal):
-            if s.schema == data:
-                return data
         else:
             message = "%r does not match %r" % (s, data)
             message = self._prepend_schema_name(message)
@@ -637,7 +639,7 @@ class Optional(Schema):
                     '"%r" is too complex.' % (self._schema,)
                 )
             self.default = default
-            self.key = self._schema
+            self.key = str(self._schema)
 
     def __hash__(self):
         return hash(self._schema)

--- a/test_schema.py
+++ b/test_schema.py
@@ -1066,6 +1066,25 @@ def test_json_schema_description_or_nested():
     }
 
 
+def test_json_schema_literal_with_enum():
+    s = Schema(
+        {
+            Literal("test", description="A test"): Or(
+                Literal("literal1", description="A literal with description"),
+                Literal("literal2", description="Another literal with description"),
+            )
+        }
+    )
+    assert s.json_schema("my-id") == {
+        "type": "object",
+        "properties": {"test": {"description": "A test", "enum": ["literal1", "literal2"]}},
+        "required": ["test"],
+        "additionalProperties": False,
+        "$id": "my-id",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+    }
+
+
 def test_json_schema_description_and_nested():
     s = Schema(
         {

--- a/test_schema.py
+++ b/test_schema.py
@@ -1123,6 +1123,11 @@ def test_description():
     assert s.validate({"test1": {}})
 
 
+def test_description_with_default():
+    s = Schema({Optional(Literal("test1", description="A description here"), default={}): dict})
+    assert s.validate({}) == {"test1": {}}
+
+
 def test_json_schema_refs():
     s = Schema({"test1": str, "test2": str, "test3": str})
     hashed = "#" + str(hash(repr(sorted({"type": "string"}.items()))))


### PR DESCRIPTION
Fixes a bug introduced by #208.

The Literal type could not be rendered in JSON because it could not be cast to string. Moreover, the implementation of Or assumed the keys were string, but they could be Literal.

Sorry for the bug!