### PR TITLE
JSON Schema: Fix using `dict` as type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -610,6 +610,7 @@ Types
     - ``float`` -> `number <https://json-schema.org/understanding-json-schema/reference/numeric.html#number>`_
     - ``bool`` -> `boolean <https://json-schema.org/understanding-json-schema/reference/boolean.html>`_
     - ``list`` -> `array <https://json-schema.org/understanding-json-schema/reference/array.html>`_
+    - ``dict`` -> `object <https://json-schema.org/understanding-json-schema/reference/object.html>`_
 
     Example:
 

--- a/schema.py
+++ b/schema.py
@@ -503,6 +503,8 @@ class Schema(object):
                     return "boolean"
                 elif python_type == list:
                     return "array"
+                elif python_type == dict:
+                    return "object"
                 return "string"
 
             def _to_schema(s, ignore_extra_keys):

--- a/test_schema.py
+++ b/test_schema.py
@@ -1015,6 +1015,19 @@ def test_json_schema_not_a_dict():
         s.json_schema("my-id")
 
 
+def test_json_schema_dict_type():
+    json_schema = Schema({Optional("test1", default={}): dict}).json_schema("my-id")
+
+    assert json_schema == {
+        "type": "object",
+        "properties": {"test1": {"type": "object"}},
+        "required": [],
+        "additionalProperties": False,
+        "$id": "my-id",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+    }
+
+
 def test_json_schema_title_and_description():
     s = Schema(
         {Literal("productId", description="The unique identifier for a product"): int},


### PR DESCRIPTION
I forgot to handle the "dict" type which would result in JSON schemas with "string" instead of "object" for parameters that are of the dict type, but that doesn't have keys specified.