### PR TITLE
README: add 3.7 to list of tested versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Use `pip <http://pip-installer.org>`_ or easy_install::
 Alternatively, you can just drop ``schema.py`` file into your project—it is
 self-contained.
 
-- **schema** is tested with Python 2.6, 2.7, 3.2, 3.3, 3.4, 3.5, 3.6 and PyPy.
+- **schema** is tested with Python 2.6, 2.7, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7 and PyPy.
 - **schema** follows `semantic versioning <http://semver.org>`_.
 
 How ``Schema`` validates data


### PR DESCRIPTION
Hi @keleshev ,
I'm very grateful for this lib. It's one of my favorite python packages - lightweight and speedy.
It seems like everything except for pre-commit `black` formatting is covered for `py37`, and it's definitely tested with 3.7.  Although I verified py37 so I can use on a current 3.7 project, it would be great if it were in the README. If there's a specific reason 3.7 isn't listed that's understandable.
Thanks again for the awesome library!
