### PR TITLE
JSON Schema: Don't add a description in a ref

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -518,7 +518,11 @@ class Schema(object):
             flavor = _priority(s)
 
             return_schema = {}
-            if description:
+
+            is_a_ref = allow_reference and schema.as_reference
+            if schema.description and not is_a_ref:
+                return_schema["description"] = schema.description
+            if description and not is_a_ref:
                 return_schema["description"] = description
 
             if flavor != DICT and is_main_schema:
@@ -575,7 +579,7 @@ class Schema(object):
                 # Schema is a dict
 
                 # Check if we have to create a common definition and use as reference
-                if allow_reference and schema.as_reference:
+                if is_a_ref:
                     # Generate sub schema if not already done
                     if schema.name not in definitions_by_name:
                         definitions_by_name[schema.name] = {}  # Avoid infinite loop
@@ -647,9 +651,6 @@ class Schema(object):
                         return_schema["definitions"] = {}
                         for definition_name, definition in definitions_by_name.items():
                             return_schema["definitions"][definition_name] = definition
-
-                if schema.description:
-                    return_schema["description"] = self.description
 
             return _create_or_use_ref(return_schema)
 

--- a/test_schema.py
+++ b/test_schema.py
@@ -1256,15 +1256,18 @@ def test_json_schema_definitions():
 def test_json_schema_definitions_and_literals():
     sub_schema = Schema({Literal("sub_key1", description="Sub key 1"): int}, name="sub_schema", as_reference=True)
     main_schema = Schema(
-        {Literal("main_key1", description="Main key 1"): str, Literal("main_key2", description="main_key2"): sub_schema}
+        {
+            Literal("main_key1", description="Main Key 1"): str,
+            Literal("main_key2", description="Main Key 2"): sub_schema,
+        }
     )
 
     json_schema = main_schema.json_schema("my-id")
     assert sorted_dict(json_schema) == {
         "type": "object",
         "properties": {
-            "main_key1": {"description": "Main key 1", "type": "string"},
-            "main_key2": {"description": "main_key2", "$ref": "#/definitions/sub_schema"},
+            "main_key1": {"description": "Main Key 1", "type": "string"},
+            "main_key2": {"$ref": "#/definitions/sub_schema"},
         },
         "required": ["main_key1", "main_key2"],
         "additionalProperties": False,


### PR DESCRIPTION
Reading [the Reuse section of Understanding JSON Schema](https://json-schema.org/understanding-json-schema/structuring.html#reuse), I notice there should be nothing other than `$ref` when reusing another section of the schema.

This fixes the library behavior by adding the description on the referenced element instead.