### PR TITLE
JSON Schema: Include default values

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -620,6 +620,8 @@ class Schema(object):
                             expanded_schema[key_name] = _json_schema(
                                 sub_schema, is_main_schema=False, description=_get_key_description(key)
                             )
+                            if isinstance(key, Optional) and hasattr(key, "default") and key.default:
+                                expanded_schema[key_name]["default"] = key.default
                         elif isinstance(key_name, Or):
                             # JSON schema does not support having a key named one name or another, so we just add both options
                             # This is less strict because we cannot enforce that one or the other is required

--- a/test_schema.py
+++ b/test_schema.py
@@ -1345,6 +1345,18 @@ def test_json_schema_definitions_invalid():
         _ = Schema({"test1": str}, as_reference=True)
 
 
+def test_json_schema_default_value():
+    s = Schema({Optional("test1", default=42): int})
+    assert s.json_schema("my-id") == {
+        "type": "object",
+        "properties": {"test1": {"type": "integer", "default": 42}},
+        "required": [],
+        "additionalProperties": False,
+        "$id": "my-id",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+    }
+
+
 def test_prepend_schema_name():
     try:
         Schema({"key1": int}).validate({"key1": "a"})


### PR DESCRIPTION
When using Optional as a key, a default value can be set. With this change, the default value will be added to the generated JSON schema as well.