### PR TITLE
Travis CI: Add Python 3.8 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ cache:
 install: pip install codecov tox
 
 script:
-  - if [ "$TOXENV" = "checks" ]; then ; pip install pre-commit ; pre-commit run -a; fi
+  - if [ "$TOXENV" = "checks" ]; then pip install pre-commit ; pre-commit run -a; fi
   - tox
 
 # publish coverage only after a successful build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
-# use new container-based infrastructure
-sudo: false
-
+os: linux
+dist: xenial
 language: python
 
-matrix:
+jobs:
   include:
     - env: TOXENV=py27
       python: 2.7
@@ -15,18 +14,18 @@ matrix:
       python: 3.6
     - env: TOXENV=py37
       python: 3.7
-      dist: xenial
-      sudo: true
+    - env: TOXENV=py38
+      python: 3.8
     - env: TOXENV=coverage
     - env: TOXENV=checks
-      python: 3.6
+      python: 3.8
 
 cache:
   pip: true
   directories:
     - .tox
 
-install: pip install codecov tox pre-commit
+install: pip install codecov pre-commit tox
 
 script:
   - if [ "$TOXENV" = "checks" ]; then pre-commit run -a; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,10 @@ cache:
   directories:
     - .tox
 
-install: pip install codecov pre-commit tox
+install: pip install codecov tox
 
 script:
-  - if [ "$TOXENV" = "checks" ]; then pre-commit run -a; fi
+  - if [ "$TOXENV" = "checks" ]; then ; pip install pre-commit ; pre-commit run -a; fi
   - tox
 
 # publish coverage only after a successful build

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: PyPy",
         "License :: OSI Approved :: MIT License",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands = pre-commit run -a
 deps = pre-commit
 
 [testenv:coverage]
-basepython=python3
+basepython=python2
 commands = coverage erase
            py.test --doctest-glob=README.rst --cov schema
            coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # install tox" and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, py36, py37, pypy, coverage, checks
+envlist = py26, py27, py32, py33, py34, py35, py36, py37, py38, pypy3, coverage, checks
 
 [testenv]
 commands = py.test
@@ -24,7 +24,7 @@ commands = pre-commit run -a
 deps = pre-commit
 
 [testenv:coverage]
-basepython=python2
+basepython=python3
 commands = coverage erase
            py.test --doctest-glob=README.rst --cov schema
            coverage report -m


### PR DESCRIPTION
The tags sudo and matrix are now deprecated and removed from Travis CI documentation.