### PR TITLE
.pre-commit-config.yaml: Add codespell, flake8, isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: flake8
         args:
           - --max-complexity=10
-          - --max-line-length=361  # 88
+          - --max-line-length=88
   - repo: https://github.com/timothycrosley/isort
     rev: 4.3.21-2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,37 @@
 repos:
--   repo: https://github.com/ambv/black
-    rev: 18.9b0
+  - repo: https://github.com/python/black
+    rev: stable
     hooks:
-    - id: black
+      - id: black
+  - repo: https://github.com/codespell-project/codespell
+    rev: v1.16.0
+    hooks:
+      - id: codespell
+        args:
+          - --quiet-level=2
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+      - id: flake8
+        args:
+          - --max-complexity=10
+          - --max-line-length=361  # 88
+  - repo: https://github.com/timothycrosley/isort
+    rev: 4.3.21-2
+    hooks:
+      - id: isort
+        args:
+          - --recursive
+  #- repo: https://github.com/pre-commit/mirrors-mypy
+  #  rev: v0.761
+  #  hooks:
+  #    - id: mypy
+        # By default, mypy will run with mypy --ignore-missing-imports,
+        # pre-commit runs mypy from an isolated virtualenv so it won't
+        # have access to those. To change the arguments, override the
+        # args as follows:
+        # args: [--no-strict-optional, --ignore-missing-imports]
+  #- repo: https://github.com/pytest-dev/pytest
+  #  rev: 5.3.4
+  #  hooks:
+  #    - id: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,32 @@
-# use new container-based infrastructure
-sudo: false
-
+os: linux
+dist: xenial
 language: python
 
-matrix:
+jobs:
   include:
     - env: TOXENV=py27
       python: 2.7
-    - env: TOXENV=py34
-      python: 3.4
     - env: TOXENV=py35
       python: 3.5
     - env: TOXENV=py36
       python: 3.6
     - env: TOXENV=py37
       python: 3.7
-      dist: xenial
-      sudo: true
+    - env: TOXENV=py38
+      python: 3.8
     - env: TOXENV=coverage
     - env: TOXENV=checks
-      python: 3.6
+      python: 3.8
 
 cache:
   pip: true
   directories:
     - .tox
 
-install: pip install codecov tox pre-commit
+install: pip install codecov tox
 
 script:
-  - if [ "$TOXENV" = "checks" ]; then pre-commit run -a; fi
+  - if [ "$TOXENV" = "checks" ]; then pip install pre-commit ; pre-commit run -a; fi
   - tox
 
 # publish coverage only after a successful build


### PR DESCRIPTION
Some functions are quite complex.  https://github.com/pycqa/mccabe  Could they be refactored?
```
black....................................................................Passed
codespell................................................................Passed
flake8...................................................................Failed
- hook id: flake8
- exit code: 1
schema.py:341:5: C901 'Schema.validate' is too complex (30)
schema.py:459:5: C901 'Schema.json_schema' is too complex (57)
test_schema.py:239:1: C901 'test_dict' is too complex (17)
isort....................................................................Passed
```