### PR TITLE
Travis CI: pypistats provides Python version info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
-# use new container-based infrastructure
-sudo: false
-
+os:linux:
+dist: xenial
 language: python
 
-matrix:
+jobs:
   include:
     - env: TOXENV=py27
       python: 2.7
@@ -15,23 +14,24 @@ matrix:
       python: 3.6
     - env: TOXENV=py37
       python: 3.7
-      dist: xenial
-      sudo: true
+    - env: TOXENV=py38
+      python: 3.8
     - env: TOXENV=coverage
-    - env: TOXENV=checks
-      python: 3.6
-
+    - python: 3.8
+      install: pip install pre-commit
+      script: pre-commit run -a
+    - python: 3.8
+      install: pip install pypistats
+      script:
+        - pypistats recent schema
+        - pypistats python_major schema --last-month
+        - pypistats python_minor schema --last-month
 cache:
   pip: true
   directories:
     - .tox
 
-install: pip install codecov tox pre-commit
-
-script:
-  - if [ "$TOXENV" = "checks" ]; then pre-commit run -a; fi
-  - tox
-
+install: pip install codecov tox
+script: tox
 # publish coverage only after a successful build
-after_success:
-  - codecov
+after_success: codecov


### PR DESCRIPTION
$ `pip install pypistats ` # https://github.com/hugovk/pypistats/blob/master/README.md
$ `pypistats recent schema`

| last_day | last_month | last_week |
|---------:|-----------:|----------:|
|   32,382 |    907,767 |   178,982 |

$ `pypistats python_major schema --last-month`

| category | percent | downloads |
|----------|--------:|----------:|
| 3        |  93.07% |   767,656 |
| 2        |   6.71% |    55,314 |
| null     |   0.22% |     1,811 |
| Total    |         |   824,781 |

Date range: 2020-03-01 - 2020-03-31

$ `pypistats python_minor schema --last-month`

| category | percent | downloads |
|----------|--------:|----------:|
| 3.6      |  62.45% |   515,085 |
| 3.7      |  23.99% |   197,869 |
| 2.7      |   6.70% |    55,227 |
| 3.5      |   3.24% |    26,696 |
| 3.8      |   3.22% |    26,599 |
| null     |   0.22% |     1,811 |
| 3.4      |   0.17% |     1,372 |
| 2.6      |   0.01% |        87 |
| 3.9      |   0.00% |        35 |
| Total    |         |   824,781 |

Date range: 2020-03-01 - 2020-03-31