### PR TITLE
JSON Schema: Add description next to $ref

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -533,10 +533,9 @@ class Schema(object):
             return_schema = {}
 
             is_a_ref = allow_reference and schema.as_reference
-            if schema.description and not is_a_ref:
-                return_schema["description"] = schema.description
-            if description and not is_a_ref:
-                return_schema["description"] = description
+            return_description = description or schema.description
+            if return_description:
+                return_schema["description"] = return_description
 
             if flavor != DICT and is_main_schema:
                 raise ValueError("The main schema must be a dict.")

--- a/test_schema.py
+++ b/test_schema.py
@@ -1326,11 +1326,17 @@ def test_json_schema_definitions():
 
 
 def test_json_schema_definitions_and_literals():
-    sub_schema = Schema({Literal("sub_key1", description="Sub key 1"): int}, name="sub_schema", as_reference=True)
+    sub_schema = Schema(
+        {Literal("sub_key1", description="Sub key 1"): int},
+        name="sub_schema",
+        as_reference=True,
+        description="Sub Schema",
+    )
     main_schema = Schema(
         {
             Literal("main_key1", description="Main Key 1"): str,
             Literal("main_key2", description="Main Key 2"): sub_schema,
+            Literal("main_key3", description="Main Key 3"): sub_schema,
         }
     )
 
@@ -1339,14 +1345,16 @@ def test_json_schema_definitions_and_literals():
         "type": "object",
         "properties": {
             "main_key1": {"description": "Main Key 1", "type": "string"},
-            "main_key2": {"$ref": "#/definitions/sub_schema"},
+            "main_key2": {"$ref": "#/definitions/sub_schema", "description": "Main Key 2"},
+            "main_key3": {"$ref": "#/definitions/sub_schema", "description": "Main Key 3"},
         },
-        "required": ["main_key1", "main_key2"],
+        "required": ["main_key1", "main_key2", "main_key3"],
         "additionalProperties": False,
         "$id": "my-id",
         "$schema": "http://json-schema.org/draft-07/schema#",
         "definitions": {
             "sub_schema": {
+                "description": "Sub Schema",
                 "type": "object",
                 "properties": {"sub_key1": {"description": "Sub key 1", "type": "integer"}},
                 "required": ["sub_key1"],


### PR DESCRIPTION
Starting with draft-04, the JSON schema specification allows having other attributes next to `$ref`. This is useful for us when using descriptions, because we may want to use a different description depending on where the sub schema is used.

Descriptions from `Literal` used as keys were already added to the value it references. With this change, descriptions will be added alongside the $ref node if the value is another schema and that schema has `as_reference` set to True.

For an example, look at `test_json_schema_definitions_and_literals`.