### PR TITLE
JSON Schema: Support schemas where the root is not a dict

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -574,9 +574,6 @@ These will appear in IDEs to help your users write a configuration.
 JSON: Supported validations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The main schema must be a dict. i.e. ``Schema({"test": str})`` works but ``Schema(str)`` does not.
-The following examples will assume the main schema is a dict.
-
 The resulting JSON schema is not guaranteed to accept the same objects as the library would accept, since some validations are not implemented or
 have no JSON schema equivalent. This is the case of the ``Use`` and ``Hook`` objects for example.
 
@@ -652,7 +649,7 @@ Types
 
     Example:
 
-    ``Regex("^v\d+")`` becomes
+    ``Schema(Regex("^v\d+"))`` becomes
 
     ``{'type': 'string', 'pattern': '^v\\d+'}``
 

--- a/schema.py
+++ b/schema.py
@@ -538,9 +538,6 @@ class Schema(object):
             if return_description:
                 return_schema["description"] = return_description
 
-            if flavor != DICT and is_main_schema:
-                raise ValueError("The main schema must be a dict.")
-
             if flavor == TYPE:
                 # Handle type
                 return_schema["type"] = _get_type_name(s)
@@ -665,15 +662,15 @@ class Schema(object):
                         }
                     )
 
-                if is_main_schema:
-                    return_schema.update({"$id": schema_id, "$schema": "http://json-schema.org/draft-07/schema#"})
-                    if self._name:
-                        return_schema["title"] = self._name
+            if is_main_schema:
+                return_schema.update({"$id": schema_id, "$schema": "http://json-schema.org/draft-07/schema#"})
+                if self._name:
+                    return_schema["title"] = self._name
 
-                    if definitions_by_name:
-                        return_schema["definitions"] = {}
-                        for definition_name, definition in definitions_by_name.items():
-                            return_schema["definitions"][definition_name] = definition
+                if definitions_by_name:
+                    return_schema["definitions"] = {}
+                    for definition_name, definition in definitions_by_name.items():
+                        return_schema["definitions"][definition_name] = definition
 
             return _create_or_use_ref(return_schema)
 


### PR DESCRIPTION
The first version of the JSON Schema generation feature did not accept having any types other than a dict for the root.

This means that calling `json_schema` on `Schema({"test": [1, 2, 3]})` would work but on `Schema([1, 2, 3])`, it would just return the error "The main schema must be a dict."

After testing, turns out this was an artificial limitation and nearly no code change is needed to have it work with any supported types.

This will also make the examples in the README actually work :)