### PR TITLE
minor > fix typo in allOf example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -673,7 +673,7 @@ Types
 
     Example:
 
-    ``Schema(And(str, "value")``
+    ``Schema(And(str, "value"))``
 
     becomes
 


### PR DESCRIPTION
Noticed a minor typo in a code example on README for creating a json schema for `"allOf"`

- Original: `Schema(And(str, "value")` _<- missing closing_ **`)`**
- Updated: `Schema(And(str, "value"))`