### PR TITLE
JSON Schema: Set additionalProperties true when dict contains str as key

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -599,7 +599,7 @@ Implemented
 
     ``{'type': 'object', 'properties': {'test': {'type': 'string'}}, 'required': [], 'additionalProperties': False}``
 
-    additionalProperties is set to true when at least one of the condition is met:
+    additionalProperties is set to true when at least one of the conditions is met:
         - ignore_extra_keys is True
         - at least one key is `str` or `object`
 

--- a/README.rst
+++ b/README.rst
@@ -599,6 +599,26 @@ Implemented
 
     ``{'type': 'object', 'properties': {'test': {'type': 'string'}}, 'required': [], 'additionalProperties': False}``
 
+    additionalProperties is set to true when at least one of the condition is met:
+        - ignore_extra_keys is True
+        - at least one key is `str` or `object`
+
+    For example:
+
+    ``Schema({str: str})`` and ``Schema({}, ignore_extra_keys=True)``
+
+    both becomes
+
+    ``{'type': 'object', 'properties' : {}, 'required': [], 'additionalProperties': True}``
+
+    and
+
+    ``Schema({})``
+
+    becomes
+
+    ``{'type': 'object', 'properties' : {}, 'required': [], 'additionalProperties': False}``
+
 Types
     Use the Python type name directly. It will be converted to the JSON name:
 
@@ -717,6 +737,7 @@ The following JSON schema validations cannot be generated from this library.
 - `Combining schemas with oneOf <https://json-schema.org/understanding-json-schema/reference/combining.html#oneof>`_
 - `Not <https://json-schema.org/understanding-json-schema/reference/combining.html#not>`_
 - `Object size <https://json-schema.org/understanding-json-schema/reference/object.html#size>`_
+- `additionalProperties having a different schema (true and false is supported)`
 
 
 JSON: Minimizing output size

--- a/test_schema.py
+++ b/test_schema.py
@@ -1082,6 +1082,40 @@ def test_json_schema_forbidden_key_ignored():
 
 
 @mark.parametrize(
+    "input_schema, ignore_extra_keys, additional_properties",
+    [
+        ({}, False, False),
+        ({str: str}, False, True),
+        ({Optional(str): str}, False, True),
+        ({object: int}, False, True),
+        ({}, True, True),
+    ],
+)
+def test_json_schema_additional_properties(input_schema, ignore_extra_keys, additional_properties):
+    s = Schema(input_schema, ignore_extra_keys=ignore_extra_keys)
+    assert s.json_schema("my-id") == {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "my-id",
+        "required": [],
+        "properties": {},
+        "additionalProperties": additional_properties,
+        "type": "object",
+    }
+
+
+def test_json_schema_additional_properties_multiple():
+    s = Schema({"named_property": bool, object: int})
+    assert s.json_schema("my-id") == {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "my-id",
+        "required": ["named_property"],
+        "properties": {"named_property": {"type": "boolean"}},
+        "additionalProperties": True,
+        "type": "object",
+    }
+
+
+@mark.parametrize(
     "input_schema, expected_keyword, expected_value",
     [
         (int, "type", "integer"),


### PR DESCRIPTION
When a dict has a `str` or `object` as one of its keys, `schema` is accepting extra keys (or additional properties in JSON schema language). However, the generated JSON schema will have `additionalPropeties` set to False.

Currently, the only way to have `additionalPropeties` set to true is to use `ignore_extra_keys` in the `Schema` object constructor. Users may not want to do that because that means that `validate` will not include the keys in the result.

This fix will have `additionalPropeties` set to true if `ignore_extra_keys` is True or if any of the key is `str` or `object` (or `Optional(str)` or `Optional(object)`).