### PR TITLE
fix: JSON Schema: Allow using $ref when schema is not a dict

### DIFF
--- a/test_schema.py
+++ b/test_schema.py
@@ -1313,6 +1313,32 @@ def test_description_with_default():
     assert s.validate({}) == {"test1": {}}
 
 
+def test_json_schema_ref_in_list():
+    s = Schema(
+        Or(
+            Schema([str], name="Inner test", as_reference=True),
+            Schema([str], name="Inner test2", as_reference=True),
+        )
+    )
+    generated_json_schema = s.json_schema("my-id")
+
+    assert generated_json_schema == {
+        "definitions": {
+            "Inner test": {
+                "items": {"type": "string"},
+                "type": "array",
+            },
+            "Inner test2": {
+                "items": {"type": "string"},
+                "type": "array",
+            },
+        },
+        "anyOf": [{"$ref": "#/definitions/Inner test"}, {"$ref": "#/definitions/Inner test2"}],
+        "$id": "my-id",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+    }
+
+
 def test_json_schema_refs():
     s = Schema({"test1": str, "test2": str, "test3": str})
     hashed = "#" + str(hash(repr(sorted({"type": "string"}.items()))))

--- a/test_schema.py
+++ b/test_schema.py
@@ -1315,23 +1315,14 @@ def test_description_with_default():
 
 def test_json_schema_ref_in_list():
     s = Schema(
-        Or(
-            Schema([str], name="Inner test", as_reference=True),
-            Schema([str], name="Inner test2", as_reference=True),
-        )
+        Or(Schema([str], name="Inner test", as_reference=True), Schema([str], name="Inner test2", as_reference=True))
     )
     generated_json_schema = s.json_schema("my-id")
 
     assert generated_json_schema == {
         "definitions": {
-            "Inner test": {
-                "items": {"type": "string"},
-                "type": "array",
-            },
-            "Inner test2": {
-                "items": {"type": "string"},
-                "type": "array",
-            },
+            "Inner test": {"items": {"type": "string"}, "type": "array"},
+            "Inner test2": {"items": {"type": "string"}, "type": "array"},
         },
         "anyOf": [{"$ref": "#/definitions/Inner test"}, {"$ref": "#/definitions/Inner test2"}],
         "$id": "my-id",


### PR DESCRIPTION
Similarly to #243, using `as_reference` only worked when the schema is an object (dict).

This change seems longer than it is, it is mainly just moving code. The part creating a $ref object has been moved to before checking the flavor, instead of being inside the `flavor == DICT` section.