### PR TITLE
Add python3.8/3.9 to the README as tested

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Use `pip <http://pip-installer.org>`_ or easy_install::
 Alternatively, you can just drop ``schema.py`` file into your project—it is
 self-contained.
 
-- **schema** is tested with Python 2.6, 2.7, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7 and PyPy.
+- **schema** is tested with Python 2.6, 2.7, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9 and PyPy.
 - **schema** follows `semantic versioning <http://semver.org>`_.
 
 How ``Schema`` validates data


### PR DESCRIPTION
In the tox.ini you are testing against many versions including python3.8 and python3.9.
Add them to the README.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>