### PR TITLE
Full subclass support for nested schemas.

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -459,7 +459,7 @@ class Schema(object):
             message = self._prepend_schema_name(message)
             raise SchemaError(message, e.format(data) if e else None)
 
-    def json_schema(self, schema_id, use_refs=False):
+    def json_schema(self, schema_id, use_refs=False, **kwargs):
         """Generate a draft-07 JSON schema dict representing the Schema.
         This method must be called with a schema_id.
 
@@ -650,7 +650,7 @@ class Schema(object):
                                 sub_schema, is_main_schema=False, description=_get_key_description(key)
                             )
                             if isinstance(key, Optional) and hasattr(key, "default"):
-                                expanded_schema[key_name]["default"] = _to_json_type(key.default() if callable(key.default) else key.default)
+                                expanded_schema[key_name]["default"] = _to_json_type(key.default(**kwargs) if callable(key.default) else key.default)
                         elif isinstance(key_name, Or):
                             # JSON schema does not support having a key named one name or another, so we just add both options
                             # This is less strict because we cannot enforce that one or the other is required

--- a/test_schema.py
+++ b/test_schema.py
@@ -701,6 +701,92 @@ def test_inheritance():
     assert d["k"] == 2 and d["d"]["k"] == 3 and d["d"]["l"][0]["l"] == [4, 5, 6]
 
 
+def test_inheritance_validate_kwargs():
+    def convert(data, increment):
+        if isinstance(data, int):
+            return data + increment
+        return data
+
+    class MySchema(Schema):
+        def validate(self, data, increment=1):
+            return super(MySchema, self).validate(
+                convert(data, increment), increment=increment)
+
+    s = {"k": int, "d": {"k": int, "l": [{"l": [int]}]}}
+    v = {"k": 1, "d": {"k": 2, "l": [{"l": [3, 4, 5]}]}}
+    d = MySchema(s).validate(v, increment=1)
+    assert d["k"] == 2 and d["d"]["k"] == 3 and d["d"]["l"][0]["l"] == [4, 5, 6]
+    d = MySchema(s).validate(v, increment=10)
+    assert d["k"] == 11 and d["d"]["k"] == 12 and d["d"]["l"][0]["l"] == [13, 14, 15]
+
+
+def test_inheritance_validate_kwargs_passed_to_nested_schema():
+    def convert(data, increment):
+        if isinstance(data, int):
+            return data + increment
+        return data
+
+    class MySchema(Schema):
+        def validate(self, data, increment=1):
+            return super(MySchema, self).validate(
+                convert(data, increment), increment=increment)
+
+    # note only d.k is under MySchema, and all others are under Schema without
+    # increment
+    s = {"k": int, "d": MySchema({"k": int, "l": [Schema({"l": [int]})]})}
+    v = {"k": 1, "d": {"k": 2, "l": [{"l": [3, 4, 5]}]}}
+    d = Schema(s).validate(v, increment=1)
+    assert d["k"] == 1 and d["d"]["k"] == 3 and d["d"]["l"][0]["l"] == [3, 4, 5]
+    d = Schema(s).validate(v, increment=10)
+    assert d["k"] == 1 and d["d"]["k"] == 12 and d["d"]["l"][0]["l"] == [3, 4, 5]
+
+
+def test_optional_callable_default_get_inherited_schema_validate_kwargs():
+    def convert(data, increment):
+        if isinstance(data, int):
+            return data + increment
+        return data
+
+    s = {"k": int, "d": {Optional("k", default=lambda **kw: convert(2, kw['increment'])): int, "l": [{"l": [int]}]}}
+    v = {"k": 1, "d": {"l": [{"l": [3, 4, 5]}]}}
+    d = Schema(s).validate(v, increment=1)
+    assert d["k"] == 1 and d["d"]["k"] == 3 and d["d"]["l"][0]["l"] == [3, 4, 5]
+    d = Schema(s).validate(v, increment=10)
+    assert d["k"] == 1 and d["d"]["k"] == 12 and d["d"]["l"][0]["l"] == [3, 4, 5]
+
+
+def test_inheritance_optional():
+    def convert(data, increment):
+        if isinstance(data, int):
+            return data + increment
+        return data
+
+    class MyOptional(Optional):
+
+        """This overrides the default property so it increments according
+        to kwargs passed to validate()
+        """
+        @property
+        def default(self):
+
+            def wrapper(**kwargs):
+                if 'increment' in kwargs:
+                    return convert(self._default, kwargs['increment'])
+                return self._default
+            return wrapper
+
+        @default.setter
+        def default(self, value):
+            self._default = value
+
+    s = {"k": int, "d": {MyOptional("k", default=2): int, "l": [{"l": [int]}]}}
+    v = {"k": 1, "d": {"l": [{"l": [3, 4, 5]}]}}
+    d = Schema(s).validate(v, increment=1)
+    assert d["k"] == 1 and d["d"]["k"] == 3 and d["d"]["l"][0]["l"] == [3, 4, 5]
+    d = Schema(s).validate(v, increment=10)
+    assert d["k"] == 1 and d["d"]["k"] == 12 and d["d"]["l"][0]["l"] == [3, 4, 5]
+
+
 def test_literal_repr():
     assert repr(Literal("test", description="testing")) == 'Literal("test", description="testing")'
     assert repr(Literal("test")) == 'Literal("test", description="")'
@@ -1003,6 +1089,34 @@ def test_json_schema_default_is_custom_type():
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
         "properties": {"test": {"default": "Hello!", "type": "string"}},
+        "required": [],
+        "additionalProperties": False,
+        "type": "object",
+    }
+
+
+def test_json_schema_default_is_callable():
+    def default_func():
+        return 'Hello!'
+    s = Schema({Optional("test", default=default_func): str})
+    assert s.json_schema("my-id") == {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "my-id",
+        "properties": {"test": {"default": "Hello!", "type": "string"}},
+        "required": [],
+        "additionalProperties": False,
+        "type": "object",
+    }
+
+
+def test_json_schema_default_is_callable_with_args_passed_from_json_schema():
+    def default_func(**kwargs):
+        return 'Hello, ' + kwargs['name']
+    s = Schema({Optional("test", default=default_func): str})
+    assert s.json_schema("my-id", name='World!') == {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "my-id",
+        "properties": {"test": {"default": "Hello, World!", "type": "string"}},
         "required": [],
         "additionalProperties": False,
         "type": "object",


### PR DESCRIPTION
Hi,

I have encounter some issues in integrating this package with the python's new dataclasses.dataclass. Most of them is due to the lack of customizability of the core classes including `Schema`, `Optional`, etc.

This pull request contains the following changes:

* Added `**kwargs` to the function signature of `Schema.validate()`. This allows subclass to override the behavior of `validate` in a propagate-able fashion. Nested `schema.Schema` class will ignore any kwargs, but nested `MySchema` class will behave accordingly. This fix #262 (@tolomea). Moreover, the kwargs passed to `validate()` is picked up by the `Optional(default=)` value when it is a callable:
```
assert Schema({Optional('a', default=lambda **k: k['some_value'])}).validate({}, some_value=1) == {'a': 1}
```

* Fix the hardcoded type check for `Optional` mentioned in #265 (@raoyitao). This allows one to implement MyOptional that consumes the kwargs passed from `validate` to callable default more integrated:

```
class MyOptional(Optional):
    @property
    def default(self):
        def wrapped(**k):
            return k['some_value']
        return wrapped
    @default.setter
    def default(self, _):
        pass # this is needed to satisfy the Optional.__init__ which does `self.default=default`
``` 

* Added `**kwargs` to the signature of `Schema.json_schema()`, and changed the handling of default values such that callable will be evaluated with the kwargs. This makes it more inline with the behavior of the `Schema.validate`:

```
    def default_func(**kwargs):
        return 'Hello, ' + kwargs['name']
    s = Schema({Optional("test", default=default_func): str})
    assert s.json_schema("my-id", name='World!') == {
        "$schema": "http://json-schema.org/draft-07/schema#",
        "$id": "my-id",
        "properties": {"test": {"default": "Hello, World!", "type": "string"}},
        "required": [],
        "additionalProperties": False,
        "type": "object",
    }
```

For more details of the changes and their implications, please take a look at the test cases I added.
  
Please let me know what you think!
