### PR TITLE
only require contextlib2 on Python < 3.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-contextlib2>=0.5.5
+contextlib2>=0.5.5; python_version < "3.3"


### PR DESCRIPTION
`contextlib.ExitStack` was added in Python 3.3