### PR TITLE
Make mock test dependency optional for Python > 3.3

### DIFF
--- a/test_schema.py
+++ b/test_schema.py
@@ -10,7 +10,10 @@ from collections import defaultdict, namedtuple
 from functools import partial
 from operator import methodcaller
 
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 from pytest import mark, raises
 
 from schema import (


### PR DESCRIPTION
Since Python 3.3 unittest.mock is available as a build in module.

Tox still mentions mock, but I have no idea how to make that optional.