### PR TITLE
fix: [JSON Schema] Type "null" should be string

### DIFF
--- a/schema/__init__.py
+++ b/schema/__init__.py
@@ -701,7 +701,7 @@ class Schema(object):
                         if len(or_values) == 1:
                             or_value = or_values[0]
                             if or_value is None:
-                                return_schema["type"] = None
+                                return_schema["type"] = "null"
                             else:
                                 return_schema["const"] = _to_json_type(or_value)
                             return return_schema
@@ -736,7 +736,7 @@ class Schema(object):
                         return_schema["allOf"] = all_of_values
                 elif flavor == COMPARABLE:
                     if s is None:
-                        return_schema["type"] = None
+                        return_schema["type"] = "null"
                     else:
                         return_schema["const"] = _to_json_type(s)
                 elif flavor == VALIDATOR and type(s) == Regex:

--- a/test_schema.py
+++ b/test_schema.py
@@ -1146,7 +1146,7 @@ def test_json_schema_const_is_none():
     assert s.json_schema("my-id") == {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "my-id",
-        "properties": {"test": {"type": None}},
+        "properties": {"test": {"type": "null"}},
         "required": ["test"],
         "additionalProperties": False,
         "type": "object",
@@ -1413,7 +1413,7 @@ def test_json_schema_dict_type():
     }
 
 
-def test_regex_json_schema():
+def test_json_schema_title_and_description():
     s = Schema(
         {
             Literal(


### PR DESCRIPTION
Fixing [my last PR ](https://github.com/keleshev/schema/pull/330)

It's
```json
{
    "type": "null"
}
```
not
```json
{
    "type": null
}
```

Also fix the name of a unit test I accidently changed

Sorry for the troubles