### PR TITLE
fix: preserve value schema for dict-of-dicts type keys in json_schema

### DIFF
--- a/schema/__init__.py
+++ b/schema/__init__.py
@@ -809,12 +809,19 @@ class Schema(object):
 
                             return key
 
-                        additional_properties = (
-                            additional_properties
-                            or _key_allows_additional_properties(key)
-                        )
+                        key_allows_additional = _key_allows_additional_properties(key)
                         sub_schema = _to_schema(s[key], ignore_extra_keys=i)
                         key_name = _get_key_name(key)
+
+                        if key_allows_additional and isinstance(s[key], dict):
+                            # Preserve the value schema of dict-of-dicts type keys
+                            additional_properties = _json_schema(
+                                sub_schema, is_main_schema=False
+                            )
+                        else:
+                            additional_properties = (
+                                additional_properties or key_allows_additional
+                            )
 
                         if isinstance(key_name, str):
                             if not isinstance(key, Optional):

--- a/test_schema.py
+++ b/test_schema.py
@@ -1349,6 +1349,23 @@ def test_json_schema_additional_properties_multiple():
     }
 
 
+def test_json_schema_dict_of_dicts_additional_properties():
+    s = Schema({str: {"property-1": str}})
+    assert s.json_schema("my-id") == {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "my-id",
+        "required": [],
+        "properties": {},
+        "additionalProperties": {
+            "type": "object",
+            "properties": {"property-1": {"type": "string"}},
+            "required": ["property-1"],
+            "additionalProperties": False,
+        },
+        "type": "object",
+    }
+
+
 @mark.parametrize(
     "input_schema, expected_keyword, expected_value",
     [


### PR DESCRIPTION
Fixes #329.

`Schema.json_schema()` dropped the value schema when a dict used a type key (`str`/`object`) mapping to a sub-schema. For `{str: {"property-1": str}}` it emitted `additionalProperties: true` and lost the nested schema entirely.

Now the value schema is rendered into `additionalProperties`, matching the expected output in the issue. Scalar cases like `{str: str}` and `{object: int}` still emit `true` as before, so existing tests are unchanged. Added a regression test.