### PR TITLE
Fix TypeError building key error message for a tuple key (#253)

### DIFF
--- a/schema/__init__.py
+++ b/schema/__init__.py
@@ -494,7 +494,7 @@ class Schema(object):
                                         svalue, error=e, ignore_extra_keys=i
                                     ).validate(value, **kwargs)
                                 except SchemaError as x:
-                                    k = "Key '%s' error:" % nkey
+                                    k = "Key '%s' error:" % (nkey,)
                                     message = self._prepend_schema_name(k)
                                     raise SchemaError(
                                         [message] + x.autos,

--- a/test_schema.py
+++ b/test_schema.py
@@ -2059,3 +2059,13 @@ def test_callable_error():
     except SchemaError as ex:
         e = ex
     assert e.errors == ["This is the error message"]
+
+
+def test_tuple_key_error_message_does_not_crash():
+    # Regression test for #253: a tuple dict key (including the empty tuple) must not raise
+    # "TypeError: not enough arguments for format string" when building the key error message.
+    assert Schema({(): [(str,)]}).is_valid({(): ["foo", ("bar",)]}) is False
+
+    with raises(SchemaError) as exc_info:
+        Schema({("a", "b"): int}).validate({("a", "b"): "not-an-int"})
+    assert "Key '('a', 'b')' error:" in exc_info.value.code


### PR DESCRIPTION
Fixes #253.

When a key's value fails validation, the key error message is built with:

```python
k = "Key '%s' error:" % nkey
```

If `nkey` is a tuple, `%` interprets it as the format arguments rather than a single value. For the empty tuple this raises `TypeError: not enough arguments for format string`, and for other tuple keys it would consume the tuple's elements as multiple format args.

```python
>>> Schema({(): [(str,)]}).is_valid({(): ["foo", ("bar",)]})
TypeError: not enough arguments for format string
```

Wrapping the key in a single-element tuple (`% (nkey,)`) formats it as one value:

```python
>>> Schema({(): [(str,)]}).is_valid({(): ["foo", ("bar",)]})
False
>>> Schema({("a", "b"): int}).validate({("a", "b"): "x"})
SchemaError: Key '('a', 'b')' error: ...
```

Added `test_tuple_key_error_message_does_not_crash`, which fails on `master` and passes with this change. All 118 existing tests still pass.

---
*Disclosure: prepared with AI assistance; reviewed by me and I can explain every line.*