### PR TITLE
Fix custom error on a key schema being lost for wrong keys

### DIFF
--- a/schema/__init__.py
+++ b/schema/__init__.py
@@ -459,6 +459,9 @@ class Schema(object):
                 if hasattr(skey, "reset"):
                     exitstack.callback(skey.reset)
 
+            # Custom errors from key schemas that rejected a data key, kept so
+            # they can be surfaced if that key ends up being a wrong key.
+            key_errors: Dict = {}
             with exitstack:
                 # Evaluate dictionaries last
                 data_items = sorted(
@@ -469,8 +472,11 @@ class Schema(object):
                         svalue = s[skey]
                         try:
                             nkey = Schema(skey, error=e).validate(key, **kwargs)
-                        except SchemaError:
-                            pass
+                        except SchemaError as x:
+                            # If the rejecting key schema carries a custom error,
+                            # remember it in case this data key is reported as wrong.
+                            if getattr(skey, "_error", None) is not None:
+                                key_errors[key] = x.code
                         else:
                             if isinstance(skey, Hook):
                                 # As the content of the value makes little sense for
@@ -525,7 +531,19 @@ class Schema(object):
                     data,
                 )
                 message = self._prepend_schema_name(message)
-                raise SchemaWrongKeyError(message, e.format(data) if e else None)
+                # Surface any custom error from the key schema(s) that rejected
+                # the wrong key(s), so an explicit `error=` is not silently lost.
+                custom_errors = [
+                    key_errors[k]
+                    for k in sorted(wrong_keys, key=repr)
+                    if k in key_errors
+                ]
+                errors: Union[List, str, None] = (
+                    [e.format(data) if e else None] + custom_errors
+                    if custom_errors
+                    else (e.format(data) if e else None)
+                )
+                raise SchemaWrongKeyError(message, errors)
 
             # Apply default-having optionals that haven't been used:
             defaults = (

--- a/test_schema.py
+++ b/test_schema.py
@@ -446,6 +446,37 @@ def test_dict_key_error():
         assert e.code == "k2 should be int"
 
 
+def test_wrong_key_reports_key_schema_error():
+    # A custom `error` on a key schema must not be lost when a data key fails to
+    # match it and is therefore reported as a wrong key (issue #345).
+    re_name = re.compile(r"^[A-Z][A-Za-z0-9]+$")
+    schema = Schema({Regex(re_name, error="Invalid profile name"): dict})
+    try:
+        schema.validate({"Foo": {}, "bar": {}})
+    except SchemaWrongKeyError as e:
+        assert e.code == "Invalid profile name"
+    else:
+        raise AssertionError("SchemaWrongKeyError not raised")
+
+    # Without a custom error the default wrong-key message is still used.
+    try:
+        Schema({Regex(re_name): dict}).validate({"Foo": {}, "bar": {}})
+    except SchemaWrongKeyError as e:
+        assert e.code == "Wrong key 'bar' in {'Foo': {}, 'bar': {}}"
+    else:
+        raise AssertionError("SchemaWrongKeyError not raised")
+
+    # The custom error is also surfaced for And-based key schemas.
+    try:
+        Schema({And(str, str.isupper, error="must be upper"): int}).validate(
+            {"FOO": 1, "bar": 2}
+        )
+    except SchemaWrongKeyError as e:
+        assert e.code == "must be upper"
+    else:
+        raise AssertionError("SchemaWrongKeyError not raised")
+
+
 def test_complex():
     s = Schema(
         {


### PR DESCRIPTION
Fixes #345.

**Bug:** when a key schema defines a custom `error`, e.g. `Schema({Regex(pattern, error="Invalid profile name"): dict})`, and a data key doesn't match it, the key is reported as a wrong key but the custom message is dropped — you only get the generic `Wrong key 'bar' in ...` and the explicit error never reaches you.

**Cause:** in `Schema.validate`'s dict branch, a key that fails to match any key schema is silently swallowed (`except SchemaError: pass`). The later `SchemaWrongKeyError` is then built only from the surrounding dict schema's own `error` (usually `None`), so the rejecting key schema's custom error is gone.

**Fix:** when a rejecting key schema carries a custom `error`, remember it, and surface it in the resulting `SchemaWrongKeyError`. The default wrong-key message is unchanged when no custom error is set.

**Testing:** added `test_wrong_key_reports_key_schema_error` (covers `Regex` and `And` key schemas, plus the no-custom-error case). Verified it fails before the fix and passes after. Full suite (120 tests) passes; ruff check/format clean; no new mypy errors.