### PR TITLE
fix: allow C-implemented built-ins (e.g. dict, int) as Optional defaults

### DIFF
--- a/schema/__init__.py
+++ b/schema/__init__.py
@@ -350,7 +350,15 @@ def _priority(s: Any) -> int:
 
 
 def _invoke_with_optional_kwargs(f: Callable[..., Any], **kwargs: Any) -> Any:
-    s = inspect.signature(f)
+    try:
+        s = inspect.signature(f)
+    except (ValueError, TypeError):
+        # Some callables -- notably C-implemented built-ins such as ``dict``
+        # or ``int`` -- do not expose an introspectable signature. We cannot
+        # tell whether they accept keyword arguments, so fall back to calling
+        # them without any, matching how such defaults behaved before
+        # validate() keyword arguments were forwarded to them.
+        return f()
     if len(s.parameters) == 0:
         return f()
     return f(**kwargs)

--- a/test_schema.py
+++ b/test_schema.py
@@ -838,6 +838,19 @@ def test_optional_callable_default_ignore_inherited_schema_validate_kwargs():
     assert d["k"] == 1 and d["d"]["k"] == 42 and d["d"]["l"][0]["l"] == [3, 4, 5]
 
 
+def test_optional_callable_default_builtin_c_callables():
+    # ``inspect.signature`` raises for some C-implemented built-ins (e.g.
+    # ``dict`` and ``int``), which previously made them unusable as
+    # ``Optional`` defaults. See https://github.com/keleshev/schema/issues/272
+    assert Schema({Optional("k", default=dict): dict}).validate({}) == {"k": {}}
+    assert Schema({Optional("k", default=int): int}).validate({}) == {"k": 0}
+    assert Schema({Optional("k", default=list): list}).validate({}) == {"k": []}
+    # validate() keyword arguments are still forwarded to callables that
+    # expose an introspectable signature accepting them.
+    s = Schema({Optional("k", default=lambda **kw: kw["increment"]): int})
+    assert s.validate({}, increment=5) == {"k": 5}
+
+
 def test_inheritance_optional():
     def convert(data, increment):
         if isinstance(data, int):


### PR DESCRIPTION
Closes #272.

### Problem

`_invoke_with_optional_kwargs` (added in #268 to forward `validate()` keyword arguments to callable `Optional` defaults) calls `inspect.signature(f)` unconditionally. For many C-implemented built-ins — `dict`, `int`, and others — `inspect.signature` raises `ValueError: no signature found for builtin type`, so those callables can no longer be used as defaults:

```python
>>> from schema import Schema, Optional
>>> Schema({Optional("k", default=dict): dict}).validate({})
ValueError: no signature found for builtin type <class 'dict'>
```

(Exactly which built-ins are affected varies by Python version — on 3.13 `dict` and `int` still raise, on older versions more do — but the breakage has been present since 0.7.5.)

### Fix

Catch the introspection failure and fall back to calling the default with no arguments. That is the only sensible call for a callable whose signature cannot be inspected, and it restores the behaviour these defaults had before keyword-argument forwarding was introduced. Callables that *do* expose a signature are untouched, so kwarg forwarding still works:

```python
>>> Schema({Optional("k", default=dict): dict}).validate({})
{'k': {}}
```

### Notes

- Added a regression test (`test_optional_callable_default_builtin_c_callables`) that also asserts `validate()` kwargs are still forwarded to introspectable callables.
- Source + test only, leaving `CHANGELOG.md` to gitchangelog (matching recent fixes such as #347).
- Full suite passes locally (`pytest`, 124 tests); `ruff` and `ruff-format` (v0.4.3) clean.
- This is a smaller, focused alternative to the now-closed #276, deliberately avoiding the kwargs-forwarding redesign that stalled that PR.