### PR TITLE
Preserve key type for Optional defaults

### DIFF
--- a/schema/__init__.py
+++ b/schema/__init__.py
@@ -905,7 +905,15 @@ class Optional(Schema):
                     f'"{self._schema!r}" is too complex.'
                 )
             self.default = default
-            self.key = str(self._schema)
+            # Preserve the original key object so the default fills the output
+            # under the same key (and key type) that a present key would use.
+            # Stringifying here made an absent optional produce ``str(key)``
+            # (e.g. ``"5"``) while a present key kept its real type (``5``).
+            self.key = (
+                self._schema.schema
+                if isinstance(self._schema, Literal)
+                else self._schema
+            )
 
     def __hash__(self) -> int:
         return hash(self._schema)

--- a/test_schema.py
+++ b/test_schema.py
@@ -419,6 +419,17 @@ def test_dict_optional_defaults():
         Optional(And(str, Use(int)), default=7)
 
 
+def test_dict_optional_default_preserves_key_type():
+    # A non-string key must keep its type when the default fills it in, just
+    # as it does when the key is present in the data.
+    for key in (5, None, 1.5):
+        schema = Schema({Optional(key, default="x"): str})
+        assert schema.validate({}) == {key: "x"}
+        # present and absent must agree on the output key type
+        present = {key: "p"}
+        assert schema.validate(present) == present
+
+
 def test_dict_subtypes():
     d = defaultdict(int, key=1)
     v = Schema({"key": 1}).validate(d)


### PR DESCRIPTION
## Summary

`Optional(key, default=...)` stringifies the key, so when the optional key is **absent** the default fills the output dict under `str(key)`, while when the key is **present** the original-typed key is used. The output key type silently depends on whether the data contained the key.

```python
from schema import Schema, Optional

s = Schema({Optional(5, default="x"): str})
s.validate({})        # -> {'5': 'x'}   (string key!)
s.validate({5: "p"})  # -> {5: 'p'}     (int key)
```

The same affects `None` (→ `'None'`), `float`, and `bool` keys. String keys are unaffected (`str("a") == "a"`), which is why the existing tests — all using string keys — never caught it.

## Cause

`Optional.__init__` set `self.key = str(self._schema)`. The default-fill path then writes `new[default.key] = ...`, so the stringified key reached the output. A present key, by contrast, flows through normally and keeps its type.

## Fix

Store the original key object (unwrapping a `Literal`, whose `str()` form the old code relied on for `description`/`title` keys), mirroring `Hook.key = self._schema`:

```python
self.key = (
    self._schema.schema
    if isinstance(self._schema, Literal)
    else self._schema
)
```

Now present and absent paths produce the same key type. `Literal` and plain string keys are unchanged.

## Verification

- Added `test_dict_optional_default_preserves_key_type`, asserting that `int`/`None`/`float` keys keep their type when filled from the default and that present/absent agree. It fails before the fix and passes after.
- Full suite: **121 passed** (was 120, no pre-existing failures). `ruff check` adds no new errors (the pre-existing `B023` reports in `json_schema` are untouched); `ruff format --check` reports already-formatted.

This pull request was prepared with the assistance of AI, under my direction and review.
