### PR TITLE
fix: tuple/list dict keys cross-match when elements overlap (fixes #312)

### DIFF
--- a/schema/__init__.py
+++ b/schema/__init__.py
@@ -471,7 +471,17 @@ class Schema(object):
                     for skey in sorted_skeys:
                         svalue = s[skey]
                         try:
-                            nkey = Schema(skey, error=e).validate(key, **kwargs)
+                            # For tuple/list schema keys, use exact comparison
+                            # to avoid cross-matching via Or semantics when
+                            # elements overlap (issue #312).
+                            if type(skey) in (tuple, list):
+                                if skey != key:
+                                    raise SchemaError(
+                                        "%r does not match %r" % (skey, key), None
+                                    )
+                                nkey = key
+                            else:
+                                nkey = Schema(skey, error=e).validate(key, **kwargs)
                         except SchemaError as x:
                             # If the rejecting key schema carries a custom error,
                             # remember it in case this data key is reported as wrong.


### PR DESCRIPTION
Tuple/list dict keys cross-match when elements overlap because
`Schema(skey).validate(key)` treats tuple keys as ITERABLE, building
`Or(*elements)` semantics. Two distinct tuple keys with overlapping
elements (e.g. `('a','b')` and `('b','b')`) interfere — the first
greedily matches the second data key.

Fixes #312.

```python
from schema import Schema
s = Schema({('a', 'b'): 'ok', ('b', 'b'): 'also ok'})
s.validate({('a', 'b'): 'ok', ('b', 'b'): 'also ok'})
# Before: SchemaMissingKeyError: Missing key: Or('b', 'b')
# After:  returns validated data
```

**Root cause:** In `Schema.validate` DICT flavor, tuple/list keys are
routed through the ITERABLE validation path which builds `Or(*elements)`,
turning key matching into set-membership instead of exact literal
comparison.

**Fix (+11/-1):** When a schema key is tuple/list, compare exactly
(`skey == key`) instead of routing through `Schema(skey).validate(key)`.
Non-tuple/list keys (strings, Optional, Or, And, Regex, etc.) continue
through the normal validation path unchanged.

120/120 tests pass.

This pull request was prepared with the assistance of AI, under my
direction and review.
