### PR TITLE
Copy non-callable Optional defaults so mutable defaults aren't shared (fixes #352)

### DIFF
--- a/schema/__init__.py
+++ b/schema/__init__.py
@@ -2,6 +2,7 @@
 obtained from config-files, forms, external services or command-line
 parsing, converted from JSON/YAML (or something else) to Python data-types."""
 
+import copy
 import inspect
 import re
 from typing import (
@@ -554,7 +555,9 @@ class Schema(object):
                 new[default.key] = (
                     _invoke_with_optional_kwargs(default.default, **kwargs)
                     if callable(default.default)
-                    else default.default
+                    # Copy non-callable defaults so a mutable default (e.g. [] or
+                    # {}) is not shared across validate() calls.
+                    else copy.deepcopy(default.default)
                 )
 
             return new

--- a/test_schema.py
+++ b/test_schema.py
@@ -419,6 +419,17 @@ def test_dict_optional_defaults():
         Optional(And(str, Use(int)), default=7)
 
 
+def test_dict_optional_mutable_default_not_shared():
+    # A mutable default (e.g. [] or {}) must not be shared across validate()
+    # calls: mutating one result must not leak into later ones. See GH-352.
+    s = Schema({Optional("items", default=[]): list})
+    a = s.validate({})
+    a["items"].append(1)
+    b = s.validate({})
+    assert b["items"] == []
+    assert a["items"] is not b["items"]
+
+
 def test_dict_subtypes():
     d = defaultdict(int, key=1)
     v = Schema({"key": 1}).validate(d)


### PR DESCRIPTION
Fixes #352.

A non-callable `default` on an `Optional` (e.g. `default=[]` or `default={}`) was inserted into every validation result **by reference**, so the same object is shared across all `validate()` calls. Mutating one result then corrupts the default for every later call:

```python
from schema import Schema, Optional
s = Schema({Optional("items", default=[]): list})
a = s.validate({}); a["items"].append(1)
b = s.validate({})
print(b["items"])   # [1]  -> should be []
```

Callable defaults (e.g. `default=list`) already returned a fresh object each time, which is why they don't have this bug.

## Fix

Deep-copy non-callable defaults so each validation gets its own object:

```python
new[default.key] = (
    _invoke_with_optional_kwargs(default.default, **kwargs)
    if callable(default.default)
    else copy.deepcopy(default.default)
)
```

## Test

Added `test_dict_optional_mutable_default_not_shared`: mutating one result's default must not leak into a later `validate()`. It fails on `master` (`[1]`) and passes with this change. Full `test_schema.py` passes (121 tests).
