### PR TITLE
Fix json_schema() dropping constraints for a Schema nested in a Schema

### DIFF
--- a/schema/__init__.py
+++ b/schema/__init__.py
@@ -701,7 +701,16 @@ class Schema(object):
                 if schema.name and not title:
                     return_schema["title"] = schema.name
 
-                if flavor == TYPE:
+                if isinstance(s, Schema):
+                    # A nested Schema instance (e.g. Const, or Schema(Schema(...)))
+                    # carries its own constraints; expand it recursively instead of
+                    # dropping it to an empty (match-anything) schema.
+                    return_schema.update(
+                        _json_schema(
+                            s, is_main_schema=False, allow_reference=allow_reference
+                        )
+                    )
+                elif flavor == TYPE:
                     # Handle type
                     return_schema["type"] = _get_type_name(s)
                 elif flavor == ITERABLE:

--- a/test_schema.py
+++ b/test_schema.py
@@ -1009,6 +1009,38 @@ def test_json_schema_nested_schema():
     }
 
 
+def test_json_schema_const_and_nested_schema():
+    # Regression: a Const (or any Schema nested directly inside another Schema)
+    # wrapping a literal/type was dropped to an empty {} schema, which accepts
+    # anything and contradicts what Schema.validate() enforces. The generated
+    # JSON schema must preserve the constraint.
+    assert Schema(Const("fixed")).json_schema("my-id") == {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "my-id",
+        "const": "fixed",
+    }
+    assert Schema(Const(int)).json_schema("my-id") == {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "my-id",
+        "type": "integer",
+    }
+    # A Schema nested directly inside another Schema must expand, not vanish.
+    assert Schema(Schema(int)).json_schema("my-id") == {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "my-id",
+        "type": "integer",
+    }
+    # Const used as a dict value keeps its const in the property schema.
+    assert Schema({"role": Const("admin")}).json_schema("my-id") == {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "my-id",
+        "type": "object",
+        "properties": {"role": {"const": "admin"}},
+        "required": ["role"],
+        "additionalProperties": False,
+    }
+
+
 def test_json_schema_optional_key():
     s = Schema({Optional("test"): str})
     assert s.json_schema("my-id") == {


### PR DESCRIPTION
### The bug

`json_schema()` renders a `Schema` nested directly inside another `Schema` as an empty `{}` schema, which matches **anything** — silently dropping the constraint and contradicting what `validate()` enforces.

```python
from schema import Schema, Const

Schema(Const("fixed")).json_schema("http://x")
# -> {'$id': 'http://x', '$schema': '...draft-07...'}      # no "const"! accepts anything

Schema(Const("fixed")).validate("other")
# -> raises SchemaError (correctly rejects)
```

So the generated JSON schema disagrees with the validator on a representable construct. The same happens for any directly-nested schema, e.g. `Schema(Schema(int)).json_schema(...)` → `{}` instead of `{"type": "integer"}`.

`Const("fixed").json_schema(...)` and `Schema("fixed").json_schema(...)` both work — the loss only happens when the `Schema`/`Const` is wrapped in another `Schema`.

### Root cause

In `Schema.json_schema`, `_priority()` classifies a `Schema` instance as `VALIDATOR`, and the only `VALIDATOR` branch in the generator handles `Regex`:

```python
elif flavor == VALIDATOR and type(s) == Regex:
    ...
else:
    if flavor != DICT:
        return return_schema    # empty {}  <-- nested Schema lands here
```

`validate()` unwraps a nested schema (`s = s.schema`), but `json_schema()` never recurses into it, so every non-`Regex` nested `Schema` falls through to the no-op default.

### Fix

Recurse into a nested `Schema` and merge its generated schema instead of dropping it:

```python
if isinstance(s, Schema):
    return_schema.update(
        _json_schema(s, is_main_schema=False, allow_reference=allow_reference)
    )
elif flavor == TYPE:
    ...
```

`Or`/`And`/`Regex` are not `Schema` subclasses, so their existing branches are unaffected; only nested `Schema` instances (`Const`, `Schema(Schema(...))`, …) now expand.

### Tests / verification

Added `test_json_schema_const_and_nested_schema` covering `Const(literal)` → `const`, `Const(type)` → `type`, `Schema(Schema(int))` → `type`, and `Const` as a dict value. The new test fails on `master` and passes with the fix. Full suite incl. the README doctests is green (121 passed); `ruff`/`ruff-format` clean; no new `mypy` findings.
